### PR TITLE
Deduplicate TPC-DS table selections in the CLI

### DIFF
--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -298,7 +298,11 @@ impl CommonArgs {
     /// Return the tables that should be generated.
     fn tables(&self) -> Result<Vec<Table>> {
         let tables = self.tables.clone().unwrap_or_else(Table::main_tables);
-        Ok(deduplicate_tables(tables))
+        let mut seen = HashSet::new();
+        Ok(tables
+            .into_iter()
+            .filter(|table| seen.insert(*table))
+            .collect())
     }
 
     /// Return the tables to generate for the row-generator outputs (DAT and
@@ -306,7 +310,19 @@ impl CommonArgs {
     /// because return files are emitted as side effects of the sales tables.
     /// Parquet has direct return-table generators and does not need expansion.
     fn row_generator_tables(&self) -> Result<Vec<Table>> {
-        Ok(normalize_row_generator_tables(self.tables()?))
+        let mut tables = Vec::new();
+        for table in self.tables()? {
+            let table = match table {
+                Table::CatalogReturns => Table::CatalogSales,
+                Table::StoreReturns => Table::StoreSales,
+                Table::WebReturns => Table::WebSales,
+                table => table,
+            };
+            if !tables.contains(&table) {
+                tables.push(table);
+            }
+        }
+        Ok(tables)
     }
 
     fn to_session(&self, table: Option<String>) -> Result<Session> {
@@ -326,28 +342,6 @@ impl CommonArgs {
 
         Ok(builder.build()?)
     }
-}
-
-/// Deduplicate parsed table selections while preserving command-line order.
-fn deduplicate_tables(tables: impl IntoIterator<Item = Table>) -> Vec<Table> {
-    let mut seen = HashSet::new();
-    tables
-        .into_iter()
-        .filter(|table| seen.insert(*table))
-        .collect()
-}
-
-/// Normalize table selections for DAT and CSV's paired row generators.
-///
-/// Each returns table is emitted by its corresponding sales generator, so
-/// selecting either or both sides of a pair must schedule that generator once.
-fn normalize_row_generator_tables(tables: impl IntoIterator<Item = Table>) -> Vec<Table> {
-    deduplicate_tables(tables.into_iter().map(|table| match table {
-        Table::CatalogReturns => Table::CatalogSales,
-        Table::StoreReturns => Table::StoreSales,
-        Table::WebReturns => Table::WebSales,
-        table => table,
-    }))
 }
 
 fn parse_table(table: &str) -> Result<Table> {
@@ -483,6 +477,18 @@ fn parse_row_group_bytes(s: &str) -> std::result::Result<usize, String> {
 mod tests {
     use super::*;
 
+    fn args_with_tables(tables: Vec<Table>) -> CommonArgs {
+        CommonArgs {
+            scale_factor: 1.0,
+            output_dir: PathBuf::new(),
+            tables: Some(tables),
+            compat: CompatMode::Trino,
+            verbose: false,
+            quiet: false,
+            progress_bars_enabled: false,
+        }
+    }
+
     #[test]
     fn every_main_table_has_help_text() {
         for table in Table::main_tables() {
@@ -494,41 +500,57 @@ mod tests {
     }
 
     #[test]
-    fn deduplicates_repeated_table_selections_in_order() {
-        let tables = deduplicate_tables([
+    fn tables_deduplicates_repeated_selections_in_first_seen_order() {
+        let tables = args_with_tables(vec![
             Table::Reason,
             Table::Reason,
             Table::ShipMode,
             Table::Reason,
             Table::ShipMode,
-        ]);
+        ])
+        .tables()
+        .unwrap();
 
         assert_eq!(tables, vec![Table::Reason, Table::ShipMode]);
     }
 
     #[test]
-    fn normalizes_every_sales_returns_pair_in_both_orders() {
+    fn row_generator_tables_collapses_sales_returns_pairs_in_both_orders() {
         for (sales, returns) in [
             (Table::CatalogSales, Table::CatalogReturns),
             (Table::StoreSales, Table::StoreReturns),
             (Table::WebSales, Table::WebReturns),
         ] {
             assert_eq!(
-                normalize_row_generator_tables([sales, returns]),
+                args_with_tables(vec![sales, returns])
+                    .row_generator_tables()
+                    .unwrap(),
                 vec![sales]
             );
             assert_eq!(
-                normalize_row_generator_tables([returns, sales]),
+                args_with_tables(vec![returns, sales])
+                    .row_generator_tables()
+                    .unwrap(),
                 vec![sales]
             );
-            assert_eq!(normalize_row_generator_tables([sales]), vec![sales]);
-            assert_eq!(normalize_row_generator_tables([returns]), vec![sales]);
+            assert_eq!(
+                args_with_tables(vec![sales])
+                    .row_generator_tables()
+                    .unwrap(),
+                vec![sales]
+            );
+            assert_eq!(
+                args_with_tables(vec![returns])
+                    .row_generator_tables()
+                    .unwrap(),
+                vec![sales]
+            );
         }
     }
 
     #[test]
-    fn normalizes_mixed_sales_returns_pairs_and_repeated_selections() {
-        let tables = normalize_row_generator_tables([
+    fn row_generator_tables_normalizes_mixed_pairs_and_duplicates() {
+        let tables = args_with_tables(vec![
             Table::StoreReturns,
             Table::Reason,
             Table::StoreSales,
@@ -538,7 +560,9 @@ mod tests {
             Table::WebReturns,
             Table::WebSales,
             Table::Reason,
-        ]);
+        ])
+        .row_generator_tables()
+        .unwrap();
 
         assert_eq!(
             tables,

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -6,6 +6,7 @@ use crate::progress::{no_op_progress_tracker, ProgressTracker};
 use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Args, Subcommand};
+use std::collections::HashSet;
 use std::io;
 #[cfg(feature = "indicatif-progress")]
 use std::io::IsTerminal;
@@ -296,10 +297,8 @@ impl CommonArgs {
 
     /// Return the tables that should be generated.
     fn tables(&self) -> Result<Vec<Table>> {
-        match &self.tables {
-            Some(tables) => Ok(tables.clone()),
-            None => Ok(Table::main_tables()),
-        }
+        let tables = self.tables.clone().unwrap_or_else(Table::main_tables);
+        Ok(deduplicate_tables(tables))
     }
 
     /// Return the tables to generate for the row-generator outputs (DAT and
@@ -307,19 +306,7 @@ impl CommonArgs {
     /// because return files are emitted as side effects of the sales tables.
     /// Parquet has direct return-table generators and does not need expansion.
     fn row_generator_tables(&self) -> Result<Vec<Table>> {
-        let mut tables = Vec::new();
-        for table in self.tables()? {
-            let table = match table {
-                Table::CatalogReturns => Table::CatalogSales,
-                Table::StoreReturns => Table::StoreSales,
-                Table::WebReturns => Table::WebSales,
-                table => table,
-            };
-            if !tables.contains(&table) {
-                tables.push(table);
-            }
-        }
-        Ok(tables)
+        Ok(normalize_row_generator_tables(self.tables()?))
     }
 
     fn to_session(&self, table: Option<String>) -> Result<Session> {
@@ -339,6 +326,28 @@ impl CommonArgs {
 
         Ok(builder.build()?)
     }
+}
+
+/// Deduplicate parsed table selections while preserving command-line order.
+fn deduplicate_tables(tables: impl IntoIterator<Item = Table>) -> Vec<Table> {
+    let mut seen = HashSet::new();
+    tables
+        .into_iter()
+        .filter(|table| seen.insert(*table))
+        .collect()
+}
+
+/// Normalize table selections for DAT and CSV's paired row generators.
+///
+/// Each returns table is emitted by its corresponding sales generator, so
+/// selecting either or both sides of a pair must schedule that generator once.
+fn normalize_row_generator_tables(tables: impl IntoIterator<Item = Table>) -> Vec<Table> {
+    deduplicate_tables(tables.into_iter().map(|table| match table {
+        Table::CatalogReturns => Table::CatalogSales,
+        Table::StoreReturns => Table::StoreSales,
+        Table::WebReturns => Table::WebSales,
+        table => table,
+    }))
 }
 
 fn parse_table(table: &str) -> Result<Table> {
@@ -482,5 +491,63 @@ mod tests {
                 "{table} is missing a --help description"
             );
         }
+    }
+
+    #[test]
+    fn deduplicates_repeated_table_selections_in_order() {
+        let tables = deduplicate_tables([
+            Table::Reason,
+            Table::Reason,
+            Table::ShipMode,
+            Table::Reason,
+            Table::ShipMode,
+        ]);
+
+        assert_eq!(tables, vec![Table::Reason, Table::ShipMode]);
+    }
+
+    #[test]
+    fn normalizes_every_sales_returns_pair_in_both_orders() {
+        for (sales, returns) in [
+            (Table::CatalogSales, Table::CatalogReturns),
+            (Table::StoreSales, Table::StoreReturns),
+            (Table::WebSales, Table::WebReturns),
+        ] {
+            assert_eq!(
+                normalize_row_generator_tables([sales, returns]),
+                vec![sales]
+            );
+            assert_eq!(
+                normalize_row_generator_tables([returns, sales]),
+                vec![sales]
+            );
+            assert_eq!(normalize_row_generator_tables([sales]), vec![sales]);
+            assert_eq!(normalize_row_generator_tables([returns]), vec![sales]);
+        }
+    }
+
+    #[test]
+    fn normalizes_mixed_sales_returns_pairs_and_repeated_selections() {
+        let tables = normalize_row_generator_tables([
+            Table::StoreReturns,
+            Table::Reason,
+            Table::StoreSales,
+            Table::StoreReturns,
+            Table::CatalogSales,
+            Table::CatalogReturns,
+            Table::WebReturns,
+            Table::WebSales,
+            Table::Reason,
+        ]);
+
+        assert_eq!(
+            tables,
+            vec![
+                Table::StoreSales,
+                Table::Reason,
+                Table::CatalogSales,
+                Table::WebSales,
+            ]
+        );
     }
 }

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -7,7 +7,6 @@ use crate::temp_path::inprogress_path;
 use crate::worker_queue::WorkerQueue;
 use arrow::record_batch::RecordBatchReader;
 use parquet::basic::Compression;
-use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::PathBuf;
@@ -57,14 +56,10 @@ impl Parquet {
         tables: Vec<(Table, Session)>,
         progress: Arc<dyn ProgressTracker>,
     ) -> io::Result<()> {
-        // Remove duplicate table selections: generating the same table
-        // twice concurrently would race on the same output file
-        let mut seen = HashSet::new();
-        let tables = tables.into_iter().filter(|(table, _)| seen.insert(*table));
-
         // Plan each table and pre-register the row group totals so trackers
         // can size their bars before the first increment
         let mut work: Vec<(Table, Session, TpcdsGenerationPlan, ProgressHandle)> = tables
+            .into_iter()
             .map(|(table, session)| {
                 let plan =
                     TpcdsGenerationPlan::new(table, session.get_scaling(), self.row_group_bytes);

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -375,6 +375,106 @@ fn test_tpcgen_cli_tpcds_dat_multiple_table_selection_command_forms() {
     }
 }
 
+/// Repeated selections and both sides of a sales/returns pair should schedule
+/// each row generator exactly once for DAT and CSV.
+#[test]
+fn test_tpcgen_cli_tpcds_row_outputs_deduplicate_selected_tables() {
+    let table_orders = [
+        "reason,reason,reason,\
+         store_sales,store_returns,store_sales,\
+         catalog_sales,catalog_returns,catalog_sales,\
+         web_sales,web_returns,web_sales",
+        "reason,reason,reason,\
+         store_returns,store_sales,store_returns,\
+         catalog_returns,catalog_sales,catalog_returns,\
+         web_returns,web_sales,web_returns",
+    ];
+
+    for tables in table_orders {
+        for (format, extension) in [("dat", "dat"), ("csv", "csv")] {
+            let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+            let assert = cargo_bin_cmd!("tpcgen-cli")
+                .arg("tpcds")
+                .arg(format)
+                .arg("--scale-factor")
+                .arg("0")
+                .arg("--tables")
+                .arg(tables)
+                .arg("--output-dir")
+                .arg(temp_dir.path())
+                .arg("--verbose")
+                .assert()
+                .success();
+
+            let expected_files = [
+                format!("reason.{extension}"),
+                format!("store_sales.{extension}"),
+                format!("store_returns.{extension}"),
+                format!("catalog_sales.{extension}"),
+                format!("catalog_returns.{extension}"),
+                format!("web_sales.{extension}"),
+                format!("web_returns.{extension}"),
+            ]
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+            let actual_files = fs::read_dir(temp_dir.path())
+                .expect("Failed to read generated output directory")
+                .map(|entry| {
+                    entry
+                        .expect("Failed to read generated output directory entry")
+                        .file_name()
+                        .into_string()
+                        .expect("Generated output file name is not valid UTF-8")
+                })
+                .collect::<BTreeSet<_>>();
+            assert_eq!(actual_files, expected_files);
+
+            let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+            assert_eq!(stderr.matches("Generating reason...").count(), 1);
+            for pair in ["store", "catalog", "web"] {
+                assert_eq!(
+                    stderr
+                        .matches(&format!("Generating {pair}_sales + {pair}_returns..."))
+                        .count(),
+                    1,
+                    "Expected the {pair} sales/returns generator to run once for {format} with {tables}, got stderr: {stderr}"
+                );
+            }
+        }
+    }
+}
+
+/// Parquet receives the same deduplicated table selection as other formats.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_deduplicates_repeated_table_selection() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0")
+        .arg("--tables")
+        .arg("reason,reason,reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .success();
+
+    let actual_files = fs::read_dir(temp_dir.path())
+        .expect("Failed to read generated output directory")
+        .map(|entry| {
+            entry
+                .expect("Failed to read generated output directory entry")
+                .file_name()
+                .into_string()
+                .expect("Generated output file name is not valid UTF-8")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual_files, vec!["reason.parquet"]);
+}
+
 /// Test each TPC-DS DAT table can be selected individually and creates output.
 #[test]
 fn test_tpcgen_cli_tpcds_dat_individual_table_selection_outputs_requested_table() {

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -445,24 +445,25 @@ fn test_tpcgen_cli_tpcds_row_outputs_deduplicate_selected_tables() {
     }
 }
 
-/// Parquet receives the same deduplicated table selection as other formats.
-#[test]
-fn test_tpcgen_cli_tpcds_parquet_deduplicates_repeated_table_selection() {
+fn generate_parquet_files(table_args: &[String]) -> BTreeSet<String> {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-    cargo_bin_cmd!("tpcgen-cli")
+    let mut command = cargo_bin_cmd!("tpcgen-cli");
+    command
         .arg("tpcds")
         .arg("parquet")
         .arg("--scale-factor")
-        .arg("0")
-        .arg("--tables")
-        .arg("reason,reason,reason")
+        .arg("0");
+    for tables in table_args {
+        command.arg("--tables").arg(tables);
+    }
+    command
         .arg("--output-dir")
         .arg(temp_dir.path())
         .assert()
         .success();
 
-    let actual_files = fs::read_dir(temp_dir.path())
+    fs::read_dir(temp_dir.path())
         .expect("Failed to read generated output directory")
         .map(|entry| {
             entry
@@ -471,8 +472,57 @@ fn test_tpcgen_cli_tpcds_parquet_deduplicates_repeated_table_selection() {
                 .into_string()
                 .expect("Generated output file name is not valid UTF-8")
         })
-        .collect::<Vec<_>>();
-    assert_eq!(actual_files, vec!["reason.parquet"]);
+        .collect()
+}
+
+/// Parquet receives the same exact-value deduplication as other formats,
+/// including when values are supplied through repeated `--tables` flags.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_deduplicates_repeated_table_selection() {
+    let expected = BTreeSet::from(["reason.parquet".to_string()]);
+    for table_args in [
+        vec!["reason,reason,reason".to_string()],
+        vec![
+            "reason".to_string(),
+            "reason".to_string(),
+            "reason".to_string(),
+        ],
+    ] {
+        assert_eq!(generate_parquet_files(&table_args), expected);
+    }
+}
+
+/// Parquet keeps sales and returns as distinct output selections while still
+/// deduplicating repeated occurrences of either table.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_preserves_sales_returns_selection_semantics() {
+    for (sales, returns) in [
+        (Table::CatalogSales, Table::CatalogReturns),
+        (Table::StoreSales, Table::StoreReturns),
+        (Table::WebSales, Table::WebReturns),
+    ] {
+        let sales = sales.get_name();
+        let returns = returns.get_name();
+
+        assert_eq!(
+            generate_parquet_files(&[sales.to_string()]),
+            BTreeSet::from([format!("{sales}.parquet")])
+        );
+        assert_eq!(
+            generate_parquet_files(&[returns.to_string()]),
+            BTreeSet::from([format!("{returns}.parquet")])
+        );
+
+        for tables in [
+            format!("{sales},{returns},{sales}"),
+            format!("{returns},{sales},{returns}"),
+        ] {
+            assert_eq!(
+                generate_parquet_files(&[tables]),
+                BTreeSet::from([format!("{sales}.parquet"), format!("{returns}.parquet"),])
+            );
+        }
+    }
 }
 
 /// Test each TPC-DS DAT table can be selected individually and creates output.


### PR DESCRIPTION
- Closes #354

## What changed

- `CommonArgs::tables()` removes repeated `--tables` values while keeping their original order. Parquet uses this list directly because it generates sales and returns separately:

  ```text
  catalog_sales,catalog_returns,catalog_sales
  → catalog_sales,catalog_returns
  ```

- DAT and CSV call `CommonArgs::row_generator_tables()`. These formats generate each sales/returns pair together, so the function maps returns tables to their sales generator and deduplicates the result:

  ```text
  catalog_sales,catalog_returns
  → catalog_sales
  ```

  The `catalog_sales` generator then writes both `catalog_sales` and `catalog_returns`.

- Remove Parquet’s duplicate cleanup because `CommonArgs::tables()` now normalizes selections before format dispatch.

- Add tests for repeated values, all sales/returns pairs, both selection orders, generator runs, and output files.

## Testing

- `cargo fmt -p tpcgen-cli -- --check`
- `cargo test -p tpcgen-cli --lib tpcds_cli::tests`
- `cargo test -p tpcgen-cli --test cli_integration tpcds::`
- `cargo clippy -p tpcgen-cli --tests -- -D warnings`