### PR TITLE
[TPC-H] Deduplicate CLI table selections

### DIFF
--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -7,6 +7,7 @@ use crate::logging::configure_logging;
 use crate::progress::IndicatifProgress;
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
+use std::collections::BTreeSet;
 use std::io;
 #[cfg(feature = "indicatif-progress")]
 use std::io::IsTerminal;
@@ -134,6 +135,8 @@ impl CommonArgs {
     /// Initialize CLI logging/progress output and create a
     /// [`TpchGeneratorBuilder`] pre-configured with the common options.
     fn builder(self, format: OutputFormat) -> TpchGeneratorBuilder {
+        let tables = self.tables();
+
         #[cfg(feature = "indicatif-progress")]
         let progress = self
             .should_show_progress_bars()
@@ -146,7 +149,7 @@ impl CommonArgs {
             .with_num_threads(self.num_threads)
             .with_stdout(self.stdout);
 
-        if let Some(tables) = self.tables {
+        if let Some(tables) = tables {
             builder = builder.with_tables(tables);
         }
         if let Some(parts) = self.parts {
@@ -171,6 +174,19 @@ impl CommonArgs {
         }
 
         builder
+    }
+
+    /// Return the selected tables without repeated values, preserving the
+    /// command-line order of their first occurrence.
+    fn tables(&self) -> Option<Vec<Table>> {
+        let mut seen = BTreeSet::new();
+        self.tables.as_ref().map(|tables| {
+            tables
+                .iter()
+                .copied()
+                .filter(|table| seen.insert(*table))
+                .collect()
+        })
     }
 
     #[cfg(feature = "indicatif-progress")]
@@ -415,5 +431,55 @@ impl ParquetArgs {
             .build()
             .generate()
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_with_tables(tables: Vec<Table>) -> CommonArgs {
+        CommonArgs {
+            scale_factor: 1.0,
+            output_dir: PathBuf::new(),
+            tables: Some(tables),
+            parts: None,
+            part: None,
+            num_threads: 1,
+            verbose: false,
+            quiet: false,
+            stdout: false,
+            progress_bars_enabled: false,
+        }
+    }
+
+    #[test]
+    fn tables_deduplicates_repeated_selections_in_first_seen_order() {
+        let tables = args_with_tables(vec![
+            Table::Region,
+            Table::Region,
+            Table::Nation,
+            Table::Region,
+            Table::Nation,
+        ])
+        .tables();
+
+        assert_eq!(tables, Some(vec![Table::Region, Table::Nation]));
+    }
+
+    #[test]
+    fn tables_deduplicates_values_from_repeated_flags_and_aliases() {
+        let cli = Cli::try_parse_from([
+            "tpchgen", "tbl", "--tables", "region,r", "--tables", "nation", "--tables", "region",
+        ])
+        .unwrap();
+        let Some(Commands::Tbl(args)) = cli.command else {
+            panic!("expected tbl command")
+        };
+
+        assert_eq!(
+            args.common.tables(),
+            Some(vec![Table::Region, Table::Nation])
+        );
     }
 }

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -7,7 +7,7 @@ use crate::logging::configure_logging;
 use crate::progress::IndicatifProgress;
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
-use std::collections::BTreeSet;
+use std::collections::HashSet;
 use std::io;
 #[cfg(feature = "indicatif-progress")]
 use std::io::IsTerminal;
@@ -179,7 +179,7 @@ impl CommonArgs {
     /// Return the selected tables without repeated values, preserving the
     /// command-line order of their first occurrence.
     fn tables(&self) -> Option<Vec<Table>> {
-        let mut seen = BTreeSet::new();
+        let mut seen = HashSet::new();
         self.tables.as_ref().map(|tables| {
             tables
                 .iter()

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -63,7 +63,7 @@ impl IntoSize for BufWriter<File> {
 ///
 /// Represents the 8 tables in the TPC-H benchmark schema.
 /// Tables are ordered by size (smallest to largest at SF=1).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Table {
     /// Nation table (25 rows)
     Nation,

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -50,6 +50,48 @@ fn test_tpcgen_cli_tpch_command_forms() {
     }
 }
 
+/// Repeated TPC-H table selections should schedule each table once for every
+/// output format.
+#[test]
+fn test_tpcgen_cli_tpch_deduplicates_selected_tables_for_all_formats() {
+    let forms: &[(&[&str], &str)] = &[
+        (&["tpch", "tbl"], "tbl"),
+        (&["tpch", "csv"], "csv"),
+        (&["tpch", "parquet"], "parquet"),
+    ];
+
+    for (form, extension) in forms {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+        let assert = cargo_bin_cmd!("tpcgen-cli")
+            .args(*form)
+            .arg("--scale-factor")
+            .arg("0.001")
+            .arg("--tables")
+            .arg("region,region,nation,region,nation")
+            .arg("--num-threads")
+            .arg("4")
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--verbose")
+            .assert()
+            .success();
+
+        assert!(temp_dir.path().join(format!("region.{extension}")).exists());
+        assert!(temp_dir.path().join(format!("nation.{extension}")).exists());
+        assert_eq!(
+            fs::read_dir(temp_dir.path())
+                .expect("Failed to read generated output directory")
+                .count(),
+            2
+        );
+
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert_eq!(stderr.matches("Writing table region").count(), 1);
+        assert_eq!(stderr.matches("Writing table nation").count(), 1);
+    }
+}
+
 /// Test TBL output for scale factor 0.001 using tpchgen-cli
 #[test]
 fn test_tpchgen_cli_tbl_scale_factor_0_001() {

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -50,46 +50,37 @@ fn test_tpcgen_cli_tpch_command_forms() {
     }
 }
 
-/// Repeated TPC-H table selections should schedule each table once for every
-/// output format.
+/// Repeated TPC-H table selections should schedule each table once.
 #[test]
-fn test_tpcgen_cli_tpch_deduplicates_selected_tables_for_all_formats() {
-    let forms: &[(&[&str], &str)] = &[
-        (&["tpch", "tbl"], "tbl"),
-        (&["tpch", "csv"], "csv"),
-        (&["tpch", "parquet"], "parquet"),
-    ];
+fn test_tpcgen_cli_tpch_deduplicates_selected_tables() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
 
-    for (form, extension) in forms {
-        let temp_dir = tempdir().expect("Failed to create temporary directory");
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "tbl"])
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("region,region,nation,region,nation")
+        .arg("--num-threads")
+        .arg("4")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--verbose")
+        .assert()
+        .success();
 
-        let assert = cargo_bin_cmd!("tpcgen-cli")
-            .args(*form)
-            .arg("--scale-factor")
-            .arg("0.001")
-            .arg("--tables")
-            .arg("region,region,nation,region,nation")
-            .arg("--num-threads")
-            .arg("4")
-            .arg("--output-dir")
-            .arg(temp_dir.path())
-            .arg("--verbose")
-            .assert()
-            .success();
+    assert!(temp_dir.path().join("region.tbl").exists());
+    assert!(temp_dir.path().join("nation.tbl").exists());
+    assert_eq!(
+        fs::read_dir(temp_dir.path())
+            .expect("Failed to read generated output directory")
+            .count(),
+        2
+    );
 
-        assert!(temp_dir.path().join(format!("region.{extension}")).exists());
-        assert!(temp_dir.path().join(format!("nation.{extension}")).exists());
-        assert_eq!(
-            fs::read_dir(temp_dir.path())
-                .expect("Failed to read generated output directory")
-                .count(),
-            2
-        );
-
-        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-        assert_eq!(stderr.matches("Writing table region").count(), 1);
-        assert_eq!(stderr.matches("Writing table nation").count(), 1);
-    }
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert_eq!(stderr.matches("Writing table region").count(), 1);
+    assert_eq!(stderr.matches("Writing table nation").count(), 1);
 }
 
 /// Test TBL output for scale factor 0.001 using tpchgen-cli


### PR DESCRIPTION
## Summary

Deduplicate TPC-H `--tables` values after Clap parsing while preserving first-seen order.

This prevents repeated selections from creating concurrent output plans for the same file, which could race on the `.inprogress` path. It applies to TBL, CSV, Parquet, repeated flags, and aliases.

Follow-up to the analogous TPC-DS discussion in #354.

## Testing

- 2 normalization unit tests
- Complete TPC-H CLI suite: 36 tests
- Formatting and Clippy