### PR TITLE
feat: show ETA in progress bars

### DIFF
--- a/tpcgen-cli/src/progress.rs
+++ b/tpcgen-cli/src/progress.rs
@@ -385,15 +385,19 @@ mod indicatif_impl {
         static STYLE: OnceLock<ProgressStyle> = OnceLock::new();
         STYLE
             .get_or_init(|| {
-                let template = format!(
-                    "{{msg:!{LABEL_WIDTH}}} [{{bar:{BAR_WIDTH}.cyan/blue}}] ({{percent:>3}}%)"
-                );
+                let template = bar_template();
                 ProgressStyle::default_bar()
                     .template(&template)
                     .expect("progress bar template is valid")
                     .progress_chars(PROGRESS_CHARS)
             })
             .clone()
+    }
+
+    fn bar_template() -> String {
+        format!(
+            "{{msg:!{LABEL_WIDTH}}} [{{bar:{BAR_WIDTH}.cyan/blue}}] ({{percent:>3}}%) ETA {{eta}}"
+        )
     }
 
     struct IndicatifLogWriter {
@@ -553,6 +557,13 @@ mod indicatif_impl {
             t.finish();
 
             assert!(t.bars.lock().unwrap()[0].is_finished());
+        }
+
+        #[test]
+        fn progress_bar_template_shows_eta() {
+            let template = bar_template();
+
+            assert!(template.ends_with("ETA {eta}"));
         }
     }
 }


### PR DESCRIPTION
- Closes #358 

## Description

Adds ETA estimate to CLI progress bars. Throughput (Bytes/second ) is harder to implement since progress is currently reported in chunks, rows, or Parquet row groups rather than bytes.

https://github.com/user-attachments/assets/d64fae3b-c285-4f3a-9bbd-507855266393
