### PR TITLE
Support a `--column-encoding` flag to specify per-column encoding for parquet files

### DIFF
--- a/tpcgen-cli/README.md
+++ b/tpcgen-cli/README.md
@@ -15,6 +15,7 @@ pip install tpcgen-cli
 tpcgen-cli tpch -s 1 --output-dir /tmp/tpch
 tpcgen-cli tpch csv -s 1 --output-dir /tmp/tpch
 tpcgen-cli tpch parquet -s 100 --tables lineitem --parts 10 --output-dir /tmp/tpch
+tpcgen-cli tpch parquet -s 1 --tables lineitem --column-encoding=l_comment=DELTA_LENGTH_BYTE_ARRAY --output-dir /tmp/tpch
 tpcgen-cli tpcds csv -s 1 --output-dir /tmp/tpcds
 tpcgen-cli tpcds csv -s 1 --delimiter='\t' --output-dir /tmp/tpcds
 ```

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -7,9 +7,10 @@ use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
 use parquet::basic::{Compression, Encoding};
-use parquet::file::properties::WriterProperties;
+use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::types::{ColumnPath, SchemaDescPtr};
+use std::collections::HashSet;
 use std::io;
 use std::io::Write;
 use std::str::FromStr;
@@ -35,6 +36,41 @@ pub(crate) fn parse_column_encoding_pair(s: &str) -> Result<(String, Encoding), 
     }
     let encoding = Encoding::from_str(encoding).map_err(|e| e.to_string())?;
     Ok((name.to_string(), encoding))
+}
+
+fn apply_column_encodings(
+    mut builder: WriterPropertiesBuilder,
+    schema: &arrow::datatypes::Schema,
+    encodings: &[(String, Encoding)],
+) -> io::Result<WriterPropertiesBuilder> {
+    let names: HashSet<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+    for (col, enc) in encodings {
+        if !names.contains(col.as_str()) {
+            return Err(io::Error::other(format!(
+                "unknown column '{col}' for --column-encoding"
+            )));
+        }
+        match enc {
+            Encoding::PLAIN_DICTIONARY | Encoding::RLE_DICTIONARY => {
+                return Err(io::Error::other(format!(
+                    "encoding {enc} cannot be set with --column-encoding; dictionary encoding is the writer default. Use a non-dictionary encoding such as PLAIN or DELTA_LENGTH_BYTE_ARRAY"
+                )));
+            }
+            #[allow(deprecated)]
+            Encoding::BIT_PACKED => {
+                return Err(io::Error::other(
+                    "encoding BIT_PACKED is not supported for Parquet writing",
+                ));
+            }
+            _ => {
+                let path = ColumnPath::from(col.as_str());
+                builder = builder
+                    .set_column_encoding(path.clone(), *enc)
+                    .set_column_dictionary_enabled(path, false);
+            }
+        }
+    }
+    Ok(builder)
 }
 
 /// Converts a set of RecordBatchReaders into a Parquet file.
@@ -68,11 +104,8 @@ where
 
     // Compute the parquet schema
     let mut builder = WriterProperties::builder().set_compression(parquet_compression);
-    for (col, enc) in column_encodings.into_iter().flatten() {
-        let path = ColumnPath::from(col.as_str());
-        builder = builder
-            .set_column_encoding(path.clone(), *enc)
-            .set_column_dictionary_enabled(path, false);
+    if let Some(encodings) = column_encodings {
+        builder = apply_column_encodings(builder, schema.as_ref(), encodings)?;
     }
     let mut writer_properties = builder.build();
     // Embed the Arrow schema in the Parquet metadata (as ArrowWriter does) so
@@ -254,5 +287,76 @@ mod tests {
 
         assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
         assert!(std::fs::metadata(output_path).unwrap().len() > 0);
+    }
+
+    async fn write_region(
+        encodings: Option<&[(String, Encoding)]>,
+        output_path: &std::path::Path,
+    ) -> io::Result<()> {
+        let writer = BufWriter::new(File::create(output_path).unwrap());
+        let tracker = Arc::new(CountingProgress::default());
+        let progress: Arc<dyn ProgressTracker> = tracker;
+        let progress = progress.register("region", 1);
+        generate_parquet(
+            writer,
+            vec![region_source()].into_iter(),
+            1,
+            Compression::UNCOMPRESSED,
+            encodings,
+            progress,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn unknown_column_encoding_returns_error() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let output_path = output_dir.path().join("unknown.parquet");
+        let err = write_region(
+            Some(&[(
+                "not_a_column".to_string(),
+                Encoding::DELTA_LENGTH_BYTE_ARRAY,
+            )]),
+            &output_path,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown column 'not_a_column'"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dictionary_column_encodings_return_error() {
+        let output_dir = tempfile::tempdir().unwrap();
+        for encoding in [Encoding::PLAIN_DICTIONARY, Encoding::RLE_DICTIONARY] {
+            let output_path = output_dir.path().join(format!("{encoding}.parquet"));
+            let err = write_region(Some(&[("r_name".to_string(), encoding)]), &output_path)
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(
+                message.contains("cannot be set with --column-encoding"),
+                "encoding {encoding}: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bit_packed_column_encoding_returns_error() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let output_path = output_dir.path().join("bit_packed.parquet");
+        #[allow(deprecated)]
+        let err = write_region(
+            Some(&[("r_regionkey".to_string(), Encoding::BIT_PACKED)]),
+            &output_path,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("BIT_PACKED is not supported"),
+            "{err}"
+        );
     }
 }

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -255,24 +255,4 @@ mod tests {
         assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
         assert!(std::fs::metadata(output_path).unwrap().len() > 0);
     }
-
-    #[test]
-    fn parse_column_encoding_pair_accepts_two_valid_pairs() {
-        assert_eq!(
-            parse_column_encoding_pair("l_comment=DELTA_LENGTH_BYTE_ARRAY").unwrap(),
-            ("l_comment".to_string(), Encoding::DELTA_LENGTH_BYTE_ARRAY)
-        );
-        assert_eq!(
-            parse_column_encoding_pair(" l_shipinstruct = delta_byte_array ").unwrap(),
-            ("l_shipinstruct".to_string(), Encoding::DELTA_BYTE_ARRAY)
-        );
-    }
-
-    #[test]
-    fn parse_column_encoding_pair_rejects_malformed_and_unknown() {
-        assert!(parse_column_encoding_pair("nocolonequal").is_err());
-        assert!(parse_column_encoding_pair("=PLAIN").is_err());
-        assert!(parse_column_encoding_pair("l_comment=").is_err());
-        assert!(parse_column_encoding_pair("l_comment=NOT_AN_ENCODING").is_err());
-    }
 }

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -6,11 +6,10 @@ use futures::StreamExt;
 use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
-use parquet::basic::{Compression, Encoding};
+use parquet::basic::{Compression, Encoding, Type};
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::file::writer::SerializedFileWriter;
-use parquet::schema::types::{ColumnPath, SchemaDescPtr};
-use std::collections::HashSet;
+use parquet::schema::types::SchemaDescPtr;
 use std::io;
 use std::io::Write;
 use std::str::FromStr;
@@ -38,18 +37,61 @@ pub(crate) fn parse_column_encoding_pair(s: &str) -> Result<(String, Encoding), 
     Ok((name.to_string(), encoding))
 }
 
+/// Returns `true` if `encoding` can be used as a column's primary (non-dictionary)
+/// encoding for `physical_type`.
+///
+/// Mirrors the parquet crate's own encoder selection: the generic path
+/// (`get_encoder` in `encodings/encoding/mod.rs`) for fixed-width physical
+/// types, and the dedicated byte-array fast path (`arrow/arrow_writer/byte_array.rs`,
+/// used for Arrow `Utf8`/`Utf8View`/`Binary`/etc. columns) for `BYTE_ARRAY`.
+///
+/// Verified against parquet 59.2.0 for every physical type our crates actually
+/// actually produce (`BOOLEAN`, `INT32`, `INT64`, `BYTE_ARRAY`); the
+/// `FLOAT`/`DOUBLE`/`INT96`/`FIXED_LEN_BYTE_ARRAY` cases follow the same
+/// source but are not currently exercised by any TPC-H/TPC-DS column.
+fn encoding_supports_physical_type(encoding: Encoding, physical_type: Type) -> bool {
+    use Type::*;
+    match encoding {
+        Encoding::PLAIN => true,
+        // RleValueEncoder only supports BoolType.
+        Encoding::RLE => physical_type == BOOLEAN,
+        // DeltaBitPackEncoder only supports Int32Type, UInt32Type, Int64Type, and UInt64Type.
+        Encoding::DELTA_BINARY_PACKED => matches!(physical_type, INT32 | INT64),
+        // DeltaLengthByteArrayEncoder / DeltaByteArrayEncoder only support byte arrays;
+        // BYTE_ARRAY columns go through the dedicated fast path, which agrees.
+        Encoding::DELTA_LENGTH_BYTE_ARRAY | Encoding::DELTA_BYTE_ARRAY => {
+            matches!(physical_type, BYTE_ARRAY | FIXED_LEN_BYTE_ARRAY)
+        }
+        // ByteStreamSplitEncoder supports FLOAT/DOUBLE/INT32/INT64; fixed-length byte
+        // arrays go through VariableWidthByteStreamSplitEncoder instead. Variable-length
+        // BYTE_ARRAY columns are not supported by the byte-array fast path.
+        Encoding::BYTE_STREAM_SPLIT => {
+            matches!(
+                physical_type,
+                FLOAT | DOUBLE | INT32 | INT64 | FIXED_LEN_BYTE_ARRAY
+            )
+        }
+        // PLAIN_DICTIONARY/RLE_DICTIONARY/BIT_PACKED are rejected before this is
+        // ever called; anything else is unknown to this writer.
+        _ => false,
+    }
+}
+
 fn apply_column_encodings(
     mut builder: WriterPropertiesBuilder,
-    schema: &arrow::datatypes::Schema,
+    parquet_schema: &SchemaDescPtr,
     encodings: &[(String, Encoding)],
 ) -> io::Result<WriterPropertiesBuilder> {
-    let names: HashSet<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
     for (col, enc) in encodings {
-        if !names.contains(col.as_str()) {
+        let Some(descr) = parquet_schema
+            .columns()
+            .iter()
+            .find(|d| d.name() == col.as_str())
+        else {
             return Err(io::Error::other(format!(
                 "unknown column '{col}' for --column-encoding"
             )));
-        }
+        };
         match enc {
             Encoding::PLAIN_DICTIONARY | Encoding::RLE_DICTIONARY => {
                 return Err(io::Error::other(format!(
@@ -63,7 +105,13 @@ fn apply_column_encodings(
                 ));
             }
             _ => {
-                let path = ColumnPath::from(col.as_str());
+                let physical_type = descr.self_type().get_physical_type();
+                if !encoding_supports_physical_type(*enc, physical_type) {
+                    return Err(io::Error::other(format!(
+                        "encoding {enc} is not valid for column '{col}' ({physical_type} physical type)"
+                    )));
+                }
+                let path = descr.path().clone();
                 builder = builder
                     .set_column_encoding(path.clone(), *enc)
                     .set_column_dictionary_enabled(path, false);
@@ -102,10 +150,24 @@ where
     };
     let schema = first_iter.schema();
 
-    // Compute the parquet schema
+    // Compute the parquet schema first: --column-encoding validation needs each
+    // column's real physical type, which only the converted parquet schema has
+    // (coerce_types doesn't depend on column encodings, so this ordering doesn't
+    // change its value).
+    let coerce_types = WriterProperties::builder()
+        .set_compression(parquet_compression)
+        .build()
+        .coerce_types();
+    let parquet_schema = Arc::new(
+        ArrowSchemaConverter::new()
+            .with_coerce_types(coerce_types)
+            .convert(&schema)
+            .unwrap(),
+    );
+
     let mut builder = WriterProperties::builder().set_compression(parquet_compression);
     if let Some(encodings) = column_encodings {
-        builder = apply_column_encodings(builder, schema.as_ref(), encodings)?;
+        builder = apply_column_encodings(builder, &parquet_schema, encodings)?;
     }
     let mut writer_properties = builder.build();
     // Embed the Arrow schema in the Parquet metadata (as ArrowWriter does) so
@@ -113,12 +175,6 @@ where
     // Time32(seconds) column in the TPC-DS dbgen_version table)
     add_encoded_arrow_schema_to_metadata(&schema, &mut writer_properties);
     let writer_properties = Arc::new(writer_properties);
-    let parquet_schema = Arc::new(
-        ArrowSchemaConverter::new()
-            .with_coerce_types(writer_properties.coerce_types())
-            .convert(&schema)
-            .unwrap(),
-    );
 
     // create a stream that computes the data for each row group
     let mut row_group_stream = futures::stream::iter(iter_iter)
@@ -358,5 +414,64 @@ mod tests {
             err.to_string().contains("BIT_PACKED is not supported"),
             "{err}"
         );
+    }
+
+    #[tokio::test]
+    async fn encoding_incompatible_with_column_type_returns_clean_error_not_panic() {
+        let output_dir = tempfile::tempdir().unwrap();
+        // r_regionkey is INT64 (not BOOLEAN): RLE only supports boolean columns.
+        // Before validating physical types, this reached the parquet crate's
+        // internal `.unwrap()` on the encoder result and panicked instead of
+        // returning an `Err`.
+        let output_path = output_dir.path().join("regionkey_rle.parquet");
+        let err = write_region(
+            Some(&[("r_regionkey".to_string(), Encoding::RLE)]),
+            &output_path,
+        )
+        .await
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("RLE is not valid for column 'r_regionkey'"),
+            "{message}"
+        );
+
+        // r_name is BYTE_ARRAY (Utf8View): DELTA_BINARY_PACKED only supports
+        // INT32/INT64 columns.
+        let output_path = output_dir.path().join("name_delta_binary_packed.parquet");
+        let err = write_region(
+            Some(&[("r_name".to_string(), Encoding::DELTA_BINARY_PACKED)]),
+            &output_path,
+        )
+        .await
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("DELTA_BINARY_PACKED is not valid for column 'r_name'"),
+            "{message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn encoding_compatible_with_column_type_succeeds() {
+        let output_dir = tempfile::tempdir().unwrap();
+
+        let output_path = output_dir.path().join("regionkey_delta.parquet");
+        write_region(
+            Some(&[("r_regionkey".to_string(), Encoding::DELTA_BINARY_PACKED)]),
+            &output_path,
+        )
+        .await
+        .unwrap();
+        assert!(std::fs::metadata(&output_path).unwrap().len() > 0);
+
+        let output_path = output_dir.path().join("name_delta_length.parquet");
+        write_region(
+            Some(&[("r_name".to_string(), Encoding::DELTA_LENGTH_BYTE_ARRAY)]),
+            &output_path,
+        )
+        .await
+        .unwrap();
+        assert!(std::fs::metadata(&output_path).unwrap().len() > 0);
     }
 }

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
-use parquet::basic::{Compression, Encoding, Type};
+use parquet::basic::{Compression, Encoding};
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::types::SchemaDescPtr;
@@ -37,46 +37,19 @@ pub(crate) fn parse_column_encoding_pair(s: &str) -> Result<(String, Encoding), 
     Ok((name.to_string(), encoding))
 }
 
-/// Returns `true` if `encoding` can be used as a column's primary (non-dictionary)
-/// encoding for `physical_type`.
+/// Applies `encodings` to `builder`.
 ///
-/// Mirrors the parquet crate's own encoder selection: the generic path
-/// (`get_encoder` in `encodings/encoding/mod.rs`) for fixed-width physical
-/// types, and the dedicated byte-array fast path (`arrow/arrow_writer/byte_array.rs`,
-/// used for Arrow `Utf8`/`Utf8View`/`Binary`/etc. columns) for `BYTE_ARRAY`.
+/// This does not check an encoding against the column's physical type
+/// (e.g. `RLE` needs a boolean column). The parquet writer already checks
+/// this when it builds the column writer, but reports it as a panic, not
+/// an `Err`. A second check here would just drift out of sync with it.
+/// Tracking issue: <TODO: link upstream arrow-rs issue>. Until it lands,
+/// `generate_parquet`'s task-join error handling catches that panic.
 ///
-/// Verified against parquet 59.2.0 for every physical type our crates actually
-/// actually produce (`BOOLEAN`, `INT32`, `INT64`, `BYTE_ARRAY`); the
-/// `FLOAT`/`DOUBLE`/`INT96`/`FIXED_LEN_BYTE_ARRAY` cases follow the same
-/// source but are not currently exercised by any TPC-H/TPC-DS column.
-fn encoding_supports_physical_type(encoding: Encoding, physical_type: Type) -> bool {
-    use Type::*;
-    match encoding {
-        Encoding::PLAIN => true,
-        // RleValueEncoder only supports BoolType.
-        Encoding::RLE => physical_type == BOOLEAN,
-        // DeltaBitPackEncoder only supports Int32Type, UInt32Type, Int64Type, and UInt64Type.
-        Encoding::DELTA_BINARY_PACKED => matches!(physical_type, INT32 | INT64),
-        // DeltaLengthByteArrayEncoder / DeltaByteArrayEncoder only support byte arrays;
-        // BYTE_ARRAY columns go through the dedicated fast path, which agrees.
-        Encoding::DELTA_LENGTH_BYTE_ARRAY | Encoding::DELTA_BYTE_ARRAY => {
-            matches!(physical_type, BYTE_ARRAY | FIXED_LEN_BYTE_ARRAY)
-        }
-        // ByteStreamSplitEncoder supports FLOAT/DOUBLE/INT32/INT64; fixed-length byte
-        // arrays go through VariableWidthByteStreamSplitEncoder instead. Variable-length
-        // BYTE_ARRAY columns are not supported by the byte-array fast path.
-        Encoding::BYTE_STREAM_SPLIT => {
-            matches!(
-                physical_type,
-                FLOAT | DOUBLE | INT32 | INT64 | FIXED_LEN_BYTE_ARRAY
-            )
-        }
-        // PLAIN_DICTIONARY/RLE_DICTIONARY/BIT_PACKED are rejected before this is
-        // ever called; anything else is unknown to this writer.
-        _ => false,
-    }
-}
-
+/// `PLAIN_DICTIONARY`, `RLE_DICTIONARY`, and `BIT_PACKED` are rejected
+/// directly, though. These are not type mismatches: dictionary encoding is
+/// a separate writer setting, not a `set_column_encoding` value, and
+/// `BIT_PACKED` is not supported for writing in this parquet version.
 fn apply_column_encodings(
     mut builder: WriterPropertiesBuilder,
     parquet_schema: &SchemaDescPtr,
@@ -105,12 +78,6 @@ fn apply_column_encodings(
                 ));
             }
             _ => {
-                let physical_type = descr.self_type().get_physical_type();
-                if !encoding_supports_physical_type(*enc, physical_type) {
-                    return Err(io::Error::other(format!(
-                        "encoding {enc} is not valid for column '{col}' ({physical_type} physical type)"
-                    )));
-                }
                 let path = descr.path().clone();
                 builder = builder
                     .set_column_encoding(path.clone(), *enc)
@@ -150,10 +117,9 @@ where
     };
     let schema = first_iter.schema();
 
-    // Compute the parquet schema first: --column-encoding validation needs each
-    // column's real physical type, which only the converted parquet schema has
-    // (coerce_types doesn't depend on column encodings, so this ordering doesn't
-    // change its value).
+    // Compute the parquet schema first. apply_column_encodings needs it to
+    // map column names to a ColumnPath and to check they exist. coerce_types
+    // does not depend on column encodings, so this order does not change it.
     let coerce_types = WriterProperties::builder()
         .set_compression(parquet_compression)
         .build()
@@ -417,39 +383,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn encoding_incompatible_with_column_type_returns_clean_error_not_panic() {
+    async fn encoding_incompatible_with_column_type_errors_instead_of_crashing() {
+        // We do not check the encoding against the column type here (see
+        // `apply_column_encodings`). The parquet writer panics on a bad
+        // match instead. We only check that the panic comes back as an
+        // `Err`, not the exact message.
+        //
+        // r_regionkey is INT64, not BOOLEAN. RLE needs a boolean column.
         let output_dir = tempfile::tempdir().unwrap();
-        // r_regionkey is INT64 (not BOOLEAN): RLE only supports boolean columns.
-        // Before validating physical types, this reached the parquet crate's
-        // internal `.unwrap()` on the encoder result and panicked instead of
-        // returning an `Err`.
         let output_path = output_dir.path().join("regionkey_rle.parquet");
-        let err = write_region(
+        assert!(write_region(
             Some(&[("r_regionkey".to_string(), Encoding::RLE)]),
-            &output_path,
+            &output_path
         )
         .await
-        .unwrap_err();
-        let message = err.to_string();
-        assert!(
-            message.contains("RLE is not valid for column 'r_regionkey'"),
-            "{message}"
-        );
-
-        // r_name is BYTE_ARRAY (Utf8View): DELTA_BINARY_PACKED only supports
-        // INT32/INT64 columns.
-        let output_path = output_dir.path().join("name_delta_binary_packed.parquet");
-        let err = write_region(
-            Some(&[("r_name".to_string(), Encoding::DELTA_BINARY_PACKED)]),
-            &output_path,
-        )
-        .await
-        .unwrap_err();
-        let message = err.to_string();
-        assert!(
-            message.contains("DELTA_BINARY_PACKED is not valid for column 'r_name'"),
-            "{message}"
-        );
+        .is_err());
     }
 
     #[tokio::test]

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -6,12 +6,13 @@ use futures::StreamExt;
 use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
-use parquet::basic::Compression;
+use parquet::basic::{Compression, Encoding};
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
-use parquet::schema::types::SchemaDescPtr;
+use parquet::schema::types::{ColumnPath, SchemaDescPtr};
 use std::io;
 use std::io::Write;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -21,6 +22,19 @@ use crate::tpch_cli::statistics::WriteStatistics;
 pub trait IntoSize {
     /// Convert the object into a size
     fn into_size(self) -> Result<usize, io::Error>;
+}
+
+pub(crate) fn parse_column_encoding_pair(s: &str) -> Result<(String, Encoding), String> {
+    let Some((name, encoding)) = s.split_once('=') else {
+        return Err(format!("expected COLUMN=ENCODING, got: '{s}'"));
+    };
+    let name = name.trim();
+    let encoding = encoding.trim();
+    if name.is_empty() || encoding.is_empty() {
+        return Err(format!("expected COLUMN=ENCODING, got: '{s}'"));
+    }
+    let encoding = Encoding::from_str(encoding).map_err(|e| e.to_string())?;
+    Ok((name.to_string(), encoding))
 }
 
 /// Converts a set of RecordBatchReaders into a Parquet file.
@@ -34,6 +48,7 @@ pub async fn generate_parquet<W, I>(
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
+    column_encodings: &[(String, Encoding)],
     progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
@@ -52,9 +67,14 @@ where
     let schema = first_iter.schema();
 
     // Compute the parquet schema
-    let mut writer_properties = WriterProperties::builder()
-        .set_compression(parquet_compression)
-        .build();
+    let mut builder = WriterProperties::builder().set_compression(parquet_compression);
+    for (col, enc) in column_encodings {
+        let path = ColumnPath::from(col.as_str());
+        builder = builder
+            .set_column_encoding(path.clone(), *enc)
+            .set_column_dictionary_enabled(path, false);
+    }
+    let mut writer_properties = builder.build();
     // Embed the Arrow schema in the Parquet metadata (as ArrowWriter does) so
     // readers recover Arrow types with no exact Parquet equivalent (e.g. the
     // Time32(seconds) column in the TPC-DS dbgen_version table)
@@ -226,6 +246,7 @@ mod tests {
             vec![region_source(), region_source()].into_iter(),
             1,
             Compression::UNCOMPRESSED,
+            &[],
             progress,
         )
         .await
@@ -233,5 +254,25 @@ mod tests {
 
         assert_eq!(tracker.increments.load(Ordering::Relaxed), 2);
         assert!(std::fs::metadata(output_path).unwrap().len() > 0);
+    }
+
+    #[test]
+    fn parse_column_encoding_pair_accepts_two_valid_pairs() {
+        assert_eq!(
+            parse_column_encoding_pair("l_comment=DELTA_LENGTH_BYTE_ARRAY").unwrap(),
+            ("l_comment".to_string(), Encoding::DELTA_LENGTH_BYTE_ARRAY)
+        );
+        assert_eq!(
+            parse_column_encoding_pair(" l_shipinstruct = delta_byte_array ").unwrap(),
+            ("l_shipinstruct".to_string(), Encoding::DELTA_BYTE_ARRAY)
+        );
+    }
+
+    #[test]
+    fn parse_column_encoding_pair_rejects_malformed_and_unknown() {
+        assert!(parse_column_encoding_pair("nocolonequal").is_err());
+        assert!(parse_column_encoding_pair("=PLAIN").is_err());
+        assert!(parse_column_encoding_pair("l_comment=").is_err());
+        assert!(parse_column_encoding_pair("l_comment=NOT_AN_ENCODING").is_err());
     }
 }

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -48,7 +48,7 @@ pub async fn generate_parquet<W, I>(
     iter_iter: I,
     num_threads: usize,
     parquet_compression: Compression,
-    column_encodings: &[(String, Encoding)],
+    column_encodings: Option<&[(String, Encoding)]>,
     progress: ProgressHandle,
 ) -> Result<(), io::Error>
 where
@@ -68,7 +68,7 @@ where
 
     // Compute the parquet schema
     let mut builder = WriterProperties::builder().set_compression(parquet_compression);
-    for (col, enc) in column_encodings {
+    for (col, enc) in column_encodings.into_iter().flatten() {
         let path = ColumnPath::from(col.as_str());
         builder = builder
             .set_column_encoding(path.clone(), *enc)
@@ -246,7 +246,7 @@ mod tests {
             vec![region_source(), region_source()].into_iter(),
             1,
             Compression::UNCOMPRESSED,
-            &[],
+            None,
             progress,
         )
         .await

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -7,7 +7,7 @@ use log::debug;
 use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
 use parquet::basic::{Compression, Encoding};
-use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
+use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder, DEFAULT_COERCE_TYPES};
 use parquet::file::writer::SerializedFileWriter;
 use parquet::schema::types::SchemaDescPtr;
 use std::io;
@@ -37,25 +37,40 @@ pub(crate) fn parse_column_encoding_pair(s: &str) -> Result<(String, Encoding), 
     Ok((name.to_string(), encoding))
 }
 
+/// Rejects an encoding `--column-encoding` cannot use.
+///
+/// Dictionary encoding is a writer setting, not a column encoding.
+/// `BIT_PACKED` is not supported for writing in this parquet version.
+pub(crate) fn reject_unsupported_encoding(encoding: Encoding) -> io::Result<()> {
+    match encoding {
+        Encoding::PLAIN_DICTIONARY | Encoding::RLE_DICTIONARY => Err(io::Error::other(format!(
+            "encoding {encoding} cannot be set with --column-encoding; dictionary encoding is the writer default. Use a non-dictionary encoding such as PLAIN or DELTA_LENGTH_BYTE_ARRAY"
+        ))),
+        #[allow(deprecated)]
+        Encoding::BIT_PACKED => Err(io::Error::other(
+            "encoding BIT_PACKED is not supported for Parquet writing",
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// Applies `encodings` to `builder`.
 ///
-/// This does not check an encoding against the column's physical type
-/// (e.g. `RLE` needs a boolean column). The parquet writer already checks
-/// this when it builds the column writer, but reports it as a panic, not
-/// an `Err`. A second check here would just drift out of sync with it.
-/// Tracking issue: <TODO: link upstream arrow-rs issue>. Until it lands,
-/// `generate_parquet`'s task-join error handling catches that panic.
+/// Does not check an encoding against the column's physical type (RLE
+/// needs a boolean column, for example). The parquet writer checks this
+/// itself, but panics instead of returning an error. Not yet filed
+/// upstream in apache/arrow-rs.
 ///
-/// `PLAIN_DICTIONARY`, `RLE_DICTIONARY`, and `BIT_PACKED` are rejected
-/// directly, though. These are not type mismatches: dictionary encoding is
-/// a separate writer setting, not a `set_column_encoding` value, and
-/// `BIT_PACKED` is not supported for writing in this parquet version.
+/// So a bad match only fails once its table starts generating, unlike an
+/// unknown column or a rejected encoding. In a multi-table run, another
+/// table can finish first.
 fn apply_column_encodings(
     mut builder: WriterPropertiesBuilder,
     parquet_schema: &SchemaDescPtr,
     encodings: &[(String, Encoding)],
 ) -> io::Result<WriterPropertiesBuilder> {
     for (col, enc) in encodings {
+        reject_unsupported_encoding(*enc)?;
         let Some(descr) = parquet_schema
             .columns()
             .iter()
@@ -65,25 +80,10 @@ fn apply_column_encodings(
                 "unknown column '{col}' for --column-encoding"
             )));
         };
-        match enc {
-            Encoding::PLAIN_DICTIONARY | Encoding::RLE_DICTIONARY => {
-                return Err(io::Error::other(format!(
-                    "encoding {enc} cannot be set with --column-encoding; dictionary encoding is the writer default. Use a non-dictionary encoding such as PLAIN or DELTA_LENGTH_BYTE_ARRAY"
-                )));
-            }
-            #[allow(deprecated)]
-            Encoding::BIT_PACKED => {
-                return Err(io::Error::other(
-                    "encoding BIT_PACKED is not supported for Parquet writing",
-                ));
-            }
-            _ => {
-                let path = descr.path().clone();
-                builder = builder
-                    .set_column_encoding(path.clone(), *enc)
-                    .set_column_dictionary_enabled(path, false);
-            }
-        }
+        let path = descr.path().clone();
+        builder = builder
+            .set_column_encoding(path.clone(), *enc)
+            .set_column_dictionary_enabled(path, false);
     }
     Ok(builder)
 }
@@ -118,15 +118,12 @@ where
     let schema = first_iter.schema();
 
     // Compute the parquet schema first. apply_column_encodings needs it to
-    // map column names to a ColumnPath and to check they exist. coerce_types
-    // does not depend on column encodings, so this order does not change it.
-    let coerce_types = WriterProperties::builder()
-        .set_compression(parquet_compression)
-        .build()
-        .coerce_types();
+    // map column names to a ColumnPath and check they exist. Nothing here
+    // sets coerce_types, so use the default constant instead of building a
+    // WriterProperties just to read it back.
     let parquet_schema = Arc::new(
         ArrowSchemaConverter::new()
-            .with_coerce_types(coerce_types)
+            .with_coerce_types(DEFAULT_COERCE_TYPES)
             .convert(&schema)
             .unwrap(),
     );
@@ -268,6 +265,17 @@ mod tests {
     };
     use tpchgen::generators::RegionGenerator;
     use tpchgen_arrow::RegionArrow;
+
+    #[test]
+    fn reject_unsupported_encoding_rejects_dictionary_and_bit_packed() {
+        assert!(reject_unsupported_encoding(Encoding::PLAIN_DICTIONARY).is_err());
+        assert!(reject_unsupported_encoding(Encoding::RLE_DICTIONARY).is_err());
+        #[allow(deprecated)]
+        {
+            assert!(reject_unsupported_encoding(Encoding::BIT_PACKED).is_err());
+        }
+        assert!(reject_unsupported_encoding(Encoding::PLAIN).is_ok());
+    }
 
     #[derive(Debug, Default)]
     struct CountingProgress {

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -130,9 +130,14 @@ struct ParquetArgs {
     ///
     /// Example: `r_reason_description=DELTA_LENGTH_BYTE_ARRAY`
     ///
-    /// Supported encodings: PLAIN, PLAIN_DICTIONARY, RLE, BIT_PACKED,
-    /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
-    /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
+    /// Supported encodings: PLAIN, RLE, DELTA_BINARY_PACKED,
+    /// DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, BYTE_STREAM_SPLIT. Each
+    /// encoding must also be valid for the target column's Parquet physical
+    /// type (e.g. RLE only applies to boolean columns).
+    ///
+    /// PLAIN_DICTIONARY, RLE_DICTIONARY, and BIT_PACKED are rejected:
+    /// dictionary encoding is the writer default and cannot be requested
+    /// through this flag, and BIT_PACKED is not supported for writing.
     #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
     column_encoding: Option<Vec<(String, Encoding)>>,
 }
@@ -224,6 +229,14 @@ impl CommonArgs {
         num_threads: usize,
         column_encoding: Option<Vec<(String, Encoding)>>,
     ) -> Result<()> {
+        if column_encoding.is_some() && self.tables.is_none() {
+            return Err(TpcdsError::new(
+                "--column-encoding requires --tables: it names columns from a specific \
+                 table's schema, and without --tables every table is generated, most of \
+                 which won't have that column",
+            )
+            .into());
+        }
         let output = parquet::Parquet::new(
             self.output_dir.clone(),
             compression,
@@ -507,6 +520,34 @@ mod tests {
             quiet: false,
             progress_bars_enabled: false,
         }
+    }
+
+    #[tokio::test]
+    async fn column_encoding_without_tables_is_rejected() {
+        let args = CommonArgs {
+            scale_factor: 0.001,
+            output_dir: PathBuf::from("/nonexistent-should-never-be-created"),
+            tables: None,
+            compat: CompatMode::Trino,
+            verbose: false,
+            quiet: false,
+            progress_bars_enabled: false,
+        };
+
+        let err = args
+            .run_parquet(
+                Compression::UNCOMPRESSED,
+                DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
+                1,
+                Some(vec![("r_reason_description".to_string(), Encoding::PLAIN)]),
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--column-encoding requires --tables"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -229,14 +229,6 @@ impl CommonArgs {
         num_threads: usize,
         column_encoding: Option<Vec<(String, Encoding)>>,
     ) -> Result<()> {
-        if column_encoding.is_some() && self.tables.is_none() {
-            return Err(TpcdsError::new(
-                "--column-encoding requires --tables: it names columns from a specific \
-                 table's schema, and without --tables every table is generated, most of \
-                 which won't have that column",
-            )
-            .into());
-        }
         let output = parquet::Parquet::new(
             self.output_dir.clone(),
             compression,
@@ -520,34 +512,6 @@ mod tests {
             quiet: false,
             progress_bars_enabled: false,
         }
-    }
-
-    #[tokio::test]
-    async fn column_encoding_without_tables_is_rejected() {
-        let args = CommonArgs {
-            scale_factor: 0.001,
-            output_dir: PathBuf::from("/nonexistent-should-never-be-created"),
-            tables: None,
-            compat: CompatMode::Trino,
-            verbose: false,
-            quiet: false,
-            progress_bars_enabled: false,
-        };
-
-        let err = args
-            .run_parquet(
-                Compression::UNCOMPRESSED,
-                DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
-                1,
-                Some(vec![("r_reason_description".to_string(), Encoding::PLAIN)]),
-            )
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("--column-encoding requires --tables"),
-            "{err}"
-        );
     }
 
     #[test]

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -134,7 +134,7 @@ struct ParquetArgs {
     /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
     /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
     #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
-    column_encoding: Vec<(String, Encoding)>,
+    column_encoding: Option<Vec<(String, Encoding)>>,
 }
 
 #[derive(Args)]
@@ -222,7 +222,7 @@ impl CommonArgs {
         compression: Compression,
         row_group_bytes: usize,
         num_threads: usize,
-        column_encoding: Vec<(String, Encoding)>,
+        column_encoding: Option<Vec<(String, Encoding)>>,
     ) -> Result<()> {
         let output = parquet::Parquet::new(
             self.output_dir.clone(),

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -1,9 +1,10 @@
 //! TPC-DS data generation CLI with a dbgen compatible API.
 use crate::logging::configure_logging;
+use crate::parquet::parse_column_encoding_pair;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
 use crate::progress::{no_op_progress_tracker, ProgressTracker};
-use crate::tpch_cli::{Compression, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+use crate::tpch_cli::{Compression, Encoding, DEFAULT_PARQUET_ROW_GROUP_BYTES};
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Args, Subcommand};
 use std::collections::HashSet;
@@ -122,6 +123,18 @@ struct ParquetArgs {
         value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
     )]
     num_threads: usize,
+
+    /// Per-column Parquet encodings (overrides writer defaults).
+    ///
+    /// Format: `COLUMN=ENCODING[,COLUMN=ENCODING...]`
+    ///
+    /// Example: `r_reason_description=DELTA_LENGTH_BYTE_ARRAY`
+    ///
+    /// Supported encodings: PLAIN, PLAIN_DICTIONARY, RLE, BIT_PACKED,
+    /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
+    /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
+    #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
+    column_encoding: Vec<(String, Encoding)>,
 }
 
 #[derive(Args)]
@@ -186,7 +199,12 @@ impl CsvArgs {
 impl ParquetArgs {
     async fn run(self) -> Result<()> {
         self.common
-            .run_parquet(self.compression, self.row_group_bytes, self.num_threads)
+            .run_parquet(
+                self.compression,
+                self.row_group_bytes,
+                self.num_threads,
+                self.column_encoding,
+            )
             .await
     }
 }
@@ -204,12 +222,14 @@ impl CommonArgs {
         compression: Compression,
         row_group_bytes: usize,
         num_threads: usize,
+        column_encoding: Vec<(String, Encoding)>,
     ) -> Result<()> {
         let output = parquet::Parquet::new(
             self.output_dir.clone(),
             compression,
             row_group_bytes,
             num_threads,
+            column_encoding,
         );
         self.run_output(OutputFormat::Parquet(output)).await
     }

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -6,7 +6,7 @@ use crate::progress::{ProgressHandle, ProgressTracker};
 use crate::temp_path::inprogress_path;
 use crate::worker_queue::WorkerQueue;
 use arrow::record_batch::RecordBatchReader;
-use parquet::basic::Compression;
+use parquet::basic::{Compression, Encoding};
 use std::fs::File;
 use std::io::{self, BufWriter};
 use std::path::PathBuf;
@@ -27,6 +27,7 @@ pub(super) struct Parquet {
     compression: Compression,
     row_group_bytes: usize,
     num_threads: usize,
+    column_encodings: Vec<(String, Encoding)>,
 }
 
 impl Parquet {
@@ -35,12 +36,14 @@ impl Parquet {
         compression: Compression,
         row_group_bytes: usize,
         num_threads: usize,
+        column_encodings: Vec<(String, Encoding)>,
     ) -> Self {
         Self {
             output_dir,
             compression,
             row_group_bytes,
             num_threads,
+            column_encodings,
         }
     }
 
@@ -465,6 +468,7 @@ impl Parquet {
             sources,
             num_threads,
             self.compression,
+            &self.column_encodings,
             progress.clone(),
         )
         .await?;

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -27,7 +27,7 @@ pub(super) struct Parquet {
     compression: Compression,
     row_group_bytes: usize,
     num_threads: usize,
-    column_encodings: Vec<(String, Encoding)>,
+    column_encodings: Option<Vec<(String, Encoding)>>,
 }
 
 impl Parquet {
@@ -36,7 +36,7 @@ impl Parquet {
         compression: Compression,
         row_group_bytes: usize,
         num_threads: usize,
-        column_encodings: Vec<(String, Encoding)>,
+        column_encodings: Option<Vec<(String, Encoding)>>,
     ) -> Self {
         Self {
             output_dir,
@@ -468,7 +468,7 @@ impl Parquet {
             sources,
             num_threads,
             self.compression,
-            &self.column_encodings,
+            self.column_encodings.as_deref(),
             progress.clone(),
         )
         .await?;

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -5,6 +5,7 @@ use crate::parquet::generate_parquet;
 use crate::progress::{ProgressHandle, ProgressTracker};
 use crate::temp_path::inprogress_path;
 use crate::worker_queue::WorkerQueue;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
 use parquet::basic::{Compression, Encoding};
 use std::fs::File;
@@ -19,6 +20,74 @@ use tpcdsgen_arrow::{
     PromotionArrow, ReasonArrow, ShipModeArrow, StoreArrow, StoreReturnsArrow, StoreSalesArrow,
     TimeDimArrow, WarehouseArrow, WebPageArrow, WebReturnsArrow, WebSalesArrow, WebSiteArrow,
 };
+
+/// Returns `table`'s Arrow schema without generating any rows. Used to
+/// validate `--column-encoding` column names against every selected table
+/// before scheduling any generation work.
+fn table_schema(table: Table, session: &Session) -> SchemaRef {
+    let session = session.clone();
+    match table {
+        Table::CallCenter => CallCenterArrow::new(session).schema(),
+        Table::CatalogPage => CatalogPageArrow::new(session).schema(),
+        Table::CatalogReturns => CatalogReturnsArrow::new(session).schema(),
+        Table::CatalogSales => CatalogSalesArrow::new(session).schema(),
+        Table::Customer => CustomerArrow::new(session).schema(),
+        Table::CustomerAddress => CustomerAddressArrow::new(session).schema(),
+        Table::CustomerDemographics => CustomerDemographicsArrow::new(session).schema(),
+        Table::DateDim => DateDimArrow::new(session).schema(),
+        Table::DbgenVersion => DbgenVersionArrow::new(session).schema(),
+        Table::HouseholdDemographics => HouseholdDemographicsArrow::new(session).schema(),
+        Table::IncomeBand => IncomeBandArrow::new(session).schema(),
+        Table::Inventory => InventoryArrow::new(session).schema(),
+        Table::Item => ItemArrow::new(session).schema(),
+        Table::Promotion => PromotionArrow::new(session).schema(),
+        Table::Reason => ReasonArrow::new(session).schema(),
+        Table::ShipMode => ShipModeArrow::new(session).schema(),
+        Table::Store => StoreArrow::new(session).schema(),
+        Table::StoreReturns => StoreReturnsArrow::new(session).schema(),
+        Table::StoreSales => StoreSalesArrow::new(session).schema(),
+        Table::TimeDim => TimeDimArrow::new(session).schema(),
+        Table::Warehouse => WarehouseArrow::new(session).schema(),
+        Table::WebPage => WebPageArrow::new(session).schema(),
+        Table::WebReturns => WebReturnsArrow::new(session).schema(),
+        Table::WebSales => WebSalesArrow::new(session).schema(),
+        Table::WebSite => WebSiteArrow::new(session).schema(),
+        _ => unreachable!("table_schema is only called for main TPC-DS tables"),
+    }
+}
+
+/// Validates that every column referenced by `encodings` exists in every one
+/// of `tables`' schemas, before any generation starts.
+///
+/// Failing here (rather than inside `generate_parquet`, once tables are
+/// already scheduled and some may be running concurrently) means a typo'd or
+/// table-specific column name can't leave one table's `.parquet` file fully
+/// written while a sibling table fails mid-run because it simply doesn't
+/// have that column.
+fn validate_column_encodings(
+    tables: &[(Table, Session)],
+    encodings: &[(String, Encoding)],
+) -> io::Result<()> {
+    for (col, _) in encodings {
+        let missing: Vec<&str> = tables
+            .iter()
+            .filter(|(table, session)| {
+                !table_schema(*table, session)
+                    .fields()
+                    .iter()
+                    .any(|f| f.name() == col)
+            })
+            .map(|(table, _)| table.get_name())
+            .collect();
+        if !missing.is_empty() {
+            return Err(io::Error::other(format!(
+                "column '{col}' for --column-encoding not found in table(s): {}",
+                missing.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
 
 /// Parquet output generator.
 #[derive(Debug, Clone)]
@@ -59,6 +128,15 @@ impl Parquet {
         tables: Vec<(Table, Session)>,
         progress: Arc<dyn ProgressTracker>,
     ) -> io::Result<()> {
+        // Validate --column-encoding columns against every selected table's
+        // schema up front: catching a missing column here means the command
+        // fails before any table starts writing, rather than after some
+        // tables have already completed while an unrelated table (that
+        // simply doesn't have the requested column) fails mid-run.
+        if let Some(encodings) = &self.column_encodings {
+            validate_column_encodings(&tables, encodings)?;
+        }
+
         // Plan each table and pre-register the row group totals so trackers
         // can size their bars before the first increment
         let mut work: Vec<(Table, Session, TpcdsGenerationPlan, ProgressHandle)> = tables
@@ -480,5 +558,51 @@ impl Parquet {
         progress.complete();
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table_sessions(tables: &[Table]) -> Vec<(Table, Session)> {
+        tables
+            .iter()
+            .map(|&table| (table, Session::default()))
+            .collect()
+    }
+
+    #[test]
+    fn validate_column_encodings_accepts_a_column_present_in_every_selected_table() {
+        // Every TPC-DS column name is prefixed by its own table (r_, cc_, ...),
+        // so "present in every selected table" only ever means a single-table
+        // selection in practice; this exercises that path.
+        let tables = table_sessions(&[Table::Reason]);
+        let encodings = [("r_reason_description".to_string(), Encoding::PLAIN)];
+        assert!(validate_column_encodings(&tables, &encodings).is_ok());
+    }
+
+    #[test]
+    fn validate_column_encodings_rejects_a_column_missing_from_one_selected_table() {
+        // r_reason_description only exists on reason, not item.
+        let tables = table_sessions(&[Table::Reason, Table::Item]);
+        let encodings = [("r_reason_description".to_string(), Encoding::PLAIN)];
+        let err = validate_column_encodings(&tables, &encodings).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("column 'r_reason_description'"),
+            "{message}"
+        );
+        assert!(
+            message.contains("table(s): item"),
+            "expected only 'item' listed as missing the column, got: {message}"
+        );
+    }
+
+    #[test]
+    fn validate_column_encodings_rejects_a_typo() {
+        let tables = table_sessions(&[Table::Reason]);
+        let encodings = [("r_reason_description_typo".to_string(), Encoding::PLAIN)];
+        assert!(validate_column_encodings(&tables, &encodings).is_err());
     }
 }

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -22,11 +22,6 @@ use tpcdsgen_arrow::{
 };
 
 /// Returns `table`'s Arrow schema. Does not generate any rows.
-///
-/// Used by [`validate_column_encodings`] to catch a typo'd
-/// `--column-encoding` column name, and by [`column_encodings_for_table`]
-/// to find which requested encodings apply to a given table. A
-/// `--column-encoding` column usually belongs to one table, not all of them.
 fn table_schema(table: Table, session: &Session) -> SchemaRef {
     let session = session.clone();
     match table {
@@ -59,19 +54,18 @@ fn table_schema(table: Table, session: &Session) -> SchemaRef {
     }
 }
 
-/// Checks that each column in `encodings` exists in at least one of
-/// `tables`' schemas. Runs before any generation starts.
+/// Checks each column in `encodings` against every table in `tables`.
 ///
-/// A `--column-encoding` column usually applies to only some of the
-/// selected tables (e.g. `r_reason_description` exists only on `reason`).
-/// [`column_encodings_for_table`] applies each encoding where it matches
-/// and skips it elsewhere. This check only catches a column name that
-/// matches no table — almost always a typo.
+/// Rejects an encoding `reject_unsupported_encoding` always rejects.
+/// Rejects a column name that matches no table (almost always a typo). A
+/// column that matches only some tables is fine: [`column_encodings_for_table`]
+/// applies it there and skips it elsewhere.
 fn validate_column_encodings(
     tables: &[(Table, Session)],
     encodings: &[(String, Encoding)],
 ) -> io::Result<()> {
-    for (col, _) in encodings {
+    for (col, enc) in encodings {
+        crate::parquet::reject_unsupported_encoding(*enc)?;
         let matches_any_table = tables.iter().any(|(table, session)| {
             table_schema(*table, session)
                 .fields()
@@ -87,8 +81,7 @@ fn validate_column_encodings(
     Ok(())
 }
 
-/// Returns the encodings from `encodings` whose column exists in `table`'s
-/// schema. A column meant for a different table is skipped, not rejected.
+/// Keeps only the encodings whose column exists in `table`'s schema.
 fn column_encodings_for_table(
     table: Table,
     session: &Session,
@@ -141,10 +134,10 @@ impl Parquet {
         tables: Vec<(Table, Session)>,
         progress: Arc<dyn ProgressTracker>,
     ) -> io::Result<()> {
-        // Catch a --column-encoding column that matches no selected table
-        // (a typo) before scheduling any work. Each table only gets the
-        // encodings for its own columns (see `column_encodings_for_table`),
-        // so a column for a different table is not an error here.
+        // Reject a --column-encoding column that matches no selected table
+        // (a typo) before any work starts. column_encodings_for_table
+        // (below) skips a column that only matches some tables, so that
+        // case is not an error.
         if let Some(encodings) = &self.column_encodings {
             validate_column_encodings(&tables, encodings)?;
         }
@@ -593,9 +586,8 @@ mod tests {
     }
 
     #[test]
-    fn validate_column_encodings_accepts_a_column_present_on_just_one_selected_table() {
+    fn validate_column_encodings_accepts_a_column_present_on_just_one_table() {
         // r_reason_description exists only on reason, not item.
-        // column_encodings_for_table skips it for item, so this is fine.
         let tables = table_sessions(&[Table::Reason, Table::Item]);
         let encodings = [("r_reason_description".to_string(), Encoding::PLAIN)];
         assert!(validate_column_encodings(&tables, &encodings).is_ok());
@@ -614,6 +606,16 @@ mod tests {
     }
 
     #[test]
+    fn validate_column_encodings_rejects_dictionary_encoding() {
+        let tables = table_sessions(&[Table::Reason]);
+        let encodings = [(
+            "r_reason_description".to_string(),
+            Encoding::PLAIN_DICTIONARY,
+        )];
+        assert!(validate_column_encodings(&tables, &encodings).is_err());
+    }
+
+    #[test]
     fn column_encodings_for_table_keeps_only_matching_columns() {
         let session = Session::default();
         let encodings = [
@@ -623,10 +625,6 @@ mod tests {
         assert_eq!(
             column_encodings_for_table(Table::Reason, &session, &encodings),
             vec![("r_reason_description".to_string(), Encoding::PLAIN)]
-        );
-        assert_eq!(
-            column_encodings_for_table(Table::Item, &session, &encodings),
-            vec![("i_item_desc".to_string(), Encoding::PLAIN)]
         );
         assert_eq!(
             column_encodings_for_table(Table::CallCenter, &session, &encodings),

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -21,9 +21,12 @@ use tpcdsgen_arrow::{
     TimeDimArrow, WarehouseArrow, WebPageArrow, WebReturnsArrow, WebSalesArrow, WebSiteArrow,
 };
 
-/// Returns `table`'s Arrow schema without generating any rows. Used to
-/// validate `--column-encoding` column names against every selected table
-/// before scheduling any generation work.
+/// Returns `table`'s Arrow schema. Does not generate any rows.
+///
+/// Used by [`validate_column_encodings`] to catch a typo'd
+/// `--column-encoding` column name, and by [`column_encodings_for_table`]
+/// to find which requested encodings apply to a given table. A
+/// `--column-encoding` column usually belongs to one table, not all of them.
 fn table_schema(table: Table, session: &Session) -> SchemaRef {
     let session = session.clone();
     match table {
@@ -56,37 +59,47 @@ fn table_schema(table: Table, session: &Session) -> SchemaRef {
     }
 }
 
-/// Validates that every column referenced by `encodings` exists in every one
-/// of `tables`' schemas, before any generation starts.
+/// Checks that each column in `encodings` exists in at least one of
+/// `tables`' schemas. Runs before any generation starts.
 ///
-/// Failing here (rather than inside `generate_parquet`, once tables are
-/// already scheduled and some may be running concurrently) means a typo'd or
-/// table-specific column name can't leave one table's `.parquet` file fully
-/// written while a sibling table fails mid-run because it simply doesn't
-/// have that column.
+/// A `--column-encoding` column usually applies to only some of the
+/// selected tables (e.g. `r_reason_description` exists only on `reason`).
+/// [`column_encodings_for_table`] applies each encoding where it matches
+/// and skips it elsewhere. This check only catches a column name that
+/// matches no table — almost always a typo.
 fn validate_column_encodings(
     tables: &[(Table, Session)],
     encodings: &[(String, Encoding)],
 ) -> io::Result<()> {
     for (col, _) in encodings {
-        let missing: Vec<&str> = tables
-            .iter()
-            .filter(|(table, session)| {
-                !table_schema(*table, session)
-                    .fields()
-                    .iter()
-                    .any(|f| f.name() == col)
-            })
-            .map(|(table, _)| table.get_name())
-            .collect();
-        if !missing.is_empty() {
+        let matches_any_table = tables.iter().any(|(table, session)| {
+            table_schema(*table, session)
+                .fields()
+                .iter()
+                .any(|f| f.name() == col)
+        });
+        if !matches_any_table {
             return Err(io::Error::other(format!(
-                "column '{col}' for --column-encoding not found in table(s): {}",
-                missing.join(", ")
+                "column '{col}' for --column-encoding not found in any selected table"
             )));
         }
     }
     Ok(())
+}
+
+/// Returns the encodings from `encodings` whose column exists in `table`'s
+/// schema. A column meant for a different table is skipped, not rejected.
+fn column_encodings_for_table(
+    table: Table,
+    session: &Session,
+    encodings: &[(String, Encoding)],
+) -> Vec<(String, Encoding)> {
+    let schema = table_schema(table, session);
+    encodings
+        .iter()
+        .filter(|(col, _)| schema.fields().iter().any(|f| f.name() == col))
+        .cloned()
+        .collect()
 }
 
 /// Parquet output generator.
@@ -128,11 +141,10 @@ impl Parquet {
         tables: Vec<(Table, Session)>,
         progress: Arc<dyn ProgressTracker>,
     ) -> io::Result<()> {
-        // Validate --column-encoding columns against every selected table's
-        // schema up front: catching a missing column here means the command
-        // fails before any table starts writing, rather than after some
-        // tables have already completed while an unrelated table (that
-        // simply doesn't have the requested column) fails mid-run.
+        // Catch a --column-encoding column that matches no selected table
+        // (a typo) before scheduling any work. Each table only gets the
+        // encodings for its own columns (see `column_encodings_for_table`),
+        // so a column for a different table is not an error here.
         if let Some(encodings) = &self.column_encodings {
             validate_column_encodings(&tables, encodings)?;
         }
@@ -532,6 +544,14 @@ impl Parquet {
     {
         let table_name = table.get_name();
         let path = self.output_dir.join(format!("{table_name}.parquet"));
+
+        // Keep only the encodings for columns on this table.
+        // --column-encoding usually targets a few tables, not all of them.
+        let column_encodings = self
+            .column_encodings
+            .as_ref()
+            .map(|encodings| column_encodings_for_table(table, &session, encodings));
+
         let sources = plan
             .into_iter()
             .map(move |range| make_reader(session.clone(), *range.start(), *range.end()));
@@ -546,7 +566,7 @@ impl Parquet {
             sources,
             num_threads,
             self.compression,
-            self.column_encodings.as_deref(),
+            column_encodings.as_deref(),
             progress.clone(),
         )
         .await?;
@@ -573,36 +593,44 @@ mod tests {
     }
 
     #[test]
-    fn validate_column_encodings_accepts_a_column_present_in_every_selected_table() {
-        // Every TPC-DS column name is prefixed by its own table (r_, cc_, ...),
-        // so "present in every selected table" only ever means a single-table
-        // selection in practice; this exercises that path.
-        let tables = table_sessions(&[Table::Reason]);
-        let encodings = [("r_reason_description".to_string(), Encoding::PLAIN)];
-        assert!(validate_column_encodings(&tables, &encodings).is_ok());
-    }
-
-    #[test]
-    fn validate_column_encodings_rejects_a_column_missing_from_one_selected_table() {
-        // r_reason_description only exists on reason, not item.
+    fn validate_column_encodings_accepts_a_column_present_on_just_one_selected_table() {
+        // r_reason_description exists only on reason, not item.
+        // column_encodings_for_table skips it for item, so this is fine.
         let tables = table_sessions(&[Table::Reason, Table::Item]);
         let encodings = [("r_reason_description".to_string(), Encoding::PLAIN)];
-        let err = validate_column_encodings(&tables, &encodings).unwrap_err();
-        let message = err.to_string();
-        assert!(
-            message.contains("column 'r_reason_description'"),
-            "{message}"
-        );
-        assert!(
-            message.contains("table(s): item"),
-            "expected only 'item' listed as missing the column, got: {message}"
-        );
+        assert!(validate_column_encodings(&tables, &encodings).is_ok());
     }
 
     #[test]
     fn validate_column_encodings_rejects_a_typo() {
         let tables = table_sessions(&[Table::Reason]);
         let encodings = [("r_reason_description_typo".to_string(), Encoding::PLAIN)];
-        assert!(validate_column_encodings(&tables, &encodings).is_err());
+        let err = validate_column_encodings(&tables, &encodings).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("column 'r_reason_description_typo'"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn column_encodings_for_table_keeps_only_matching_columns() {
+        let session = Session::default();
+        let encodings = [
+            ("r_reason_description".to_string(), Encoding::PLAIN),
+            ("i_item_desc".to_string(), Encoding::PLAIN),
+        ];
+        assert_eq!(
+            column_encodings_for_table(Table::Reason, &session, &encodings),
+            vec![("r_reason_description".to_string(), Encoding::PLAIN)]
+        );
+        assert_eq!(
+            column_encodings_for_table(Table::Item, &session, &encodings),
+            vec![("i_item_desc".to_string(), Encoding::PLAIN)]
+        );
+        assert_eq!(
+            column_encodings_for_table(Table::CallCenter, &session, &encodings),
+            Vec::new()
+        );
     }
 }

--- a/tpcgen-cli/src/tpch_cli.rs
+++ b/tpcgen-cli/src/tpch_cli.rs
@@ -14,7 +14,7 @@ pub mod tbl;
 pub use crate::progress;
 pub use cli::Cli;
 pub use generator::{
-    Compression, GeneratorConfig, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
-    WriterSink,
+    Compression, Encoding, GeneratorConfig, OutputFormat, Table, TpchGenerator,
+    TpchGeneratorBuilder, WriterSink,
 };
 pub use plan::{GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -282,9 +282,14 @@ struct ParquetArgs {
     ///
     /// Example: `l_comment=DELTA_LENGTH_BYTE_ARRAY,l_shipinstruct=DELTA_LENGTH_BYTE_ARRAY`
     ///
-    /// Supported encodings: PLAIN, PLAIN_DICTIONARY, RLE, BIT_PACKED,
-    /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
-    /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
+    /// Supported encodings: PLAIN, RLE, DELTA_BINARY_PACKED,
+    /// DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY, BYTE_STREAM_SPLIT. Each
+    /// encoding must also be valid for the target column's Parquet physical
+    /// type (e.g. RLE only applies to boolean columns).
+    ///
+    /// PLAIN_DICTIONARY, RLE_DICTIONARY, and BIT_PACKED are rejected:
+    /// dictionary encoding is the writer default and cannot be requested
+    /// through this flag, and BIT_PACKED is not supported for writing.
     #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
     column_encoding: Option<Vec<(String, Encoding)>>,
 }
@@ -437,6 +442,13 @@ impl CsvArgs {
 
 impl ParquetArgs {
     async fn run(self) -> io::Result<()> {
+        if self.column_encoding.is_some() && self.common.tables.is_none() {
+            return Err(io::Error::other(
+                "--column-encoding requires --tables: it names columns from a specific \
+                 table's schema, and without --tables every table is generated, most of \
+                 which won't have that column",
+            ));
+        }
         self.common
             .builder(OutputFormat::Parquet)
             .with_parquet_compression(self.compression)
@@ -479,6 +491,29 @@ mod tests {
         .tables();
 
         assert_eq!(tables, Some(vec![Table::Region, Table::Nation]));
+    }
+
+    #[tokio::test]
+    async fn column_encoding_without_tables_is_rejected() {
+        let cli = Cli::try_parse_from([
+            "tpchgen",
+            "parquet",
+            "--column-encoding",
+            "l_comment=PLAIN",
+            "--output-dir",
+            "/nonexistent-should-never-be-created",
+        ])
+        .unwrap();
+        let Some(Commands::Parquet(args)) = cli.command else {
+            panic!("expected parquet command")
+        };
+
+        let err = args.run().await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--column-encoding requires --tables"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -286,7 +286,7 @@ struct ParquetArgs {
     /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
     /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
     #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
-    column_encoding: Vec<(String, Encoding)>,
+    column_encoding: Option<Vec<(String, Encoding)>>,
 }
 
 /// Parse a delimiter string, handling escape sequences.

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -1,8 +1,9 @@
 use super::{
-    Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
+    Compression, Encoding, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
     DEFAULT_PARQUET_ROW_GROUP_BYTES,
 };
 use crate::logging::configure_logging;
+use crate::parquet::parse_column_encoding_pair;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
 use clap::builder::TypedValueParser;
@@ -274,6 +275,18 @@ struct ParquetArgs {
     /// Typical values range from 10MB to 100MB.
     #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
     row_group_bytes: i64,
+
+    /// Per-column Parquet encodings (overrides writer defaults).
+    ///
+    /// Format: `COLUMN=ENCODING[,COLUMN=ENCODING...]`
+    ///
+    /// Example: `l_comment=DELTA_LENGTH_BYTE_ARRAY,l_shipinstruct=DELTA_LENGTH_BYTE_ARRAY`
+    ///
+    /// Supported encodings: PLAIN, PLAIN_DICTIONARY, RLE, BIT_PACKED,
+    /// DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, DELTA_BYTE_ARRAY,
+    /// RLE_DICTIONARY, BYTE_STREAM_SPLIT
+    #[arg(long, value_delimiter = ',', value_parser = parse_column_encoding_pair)]
+    column_encoding: Vec<(String, Encoding)>,
 }
 
 /// Parse a delimiter string, handling escape sequences.
@@ -428,6 +441,7 @@ impl ParquetArgs {
             .builder(OutputFormat::Parquet)
             .with_parquet_compression(self.compression)
             .with_parquet_row_group_bytes(self.row_group_bytes)
+            .with_parquet_column_encodings(self.column_encoding)
             .build()
             .generate()
             .await

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -442,13 +442,6 @@ impl CsvArgs {
 
 impl ParquetArgs {
     async fn run(self) -> io::Result<()> {
-        if self.column_encoding.is_some() && self.common.tables.is_none() {
-            return Err(io::Error::other(
-                "--column-encoding requires --tables: it names columns from a specific \
-                 table's schema, and without --tables every table is generated, most of \
-                 which won't have that column",
-            ));
-        }
         self.common
             .builder(OutputFormat::Parquet)
             .with_parquet_compression(self.compression)
@@ -491,29 +484,6 @@ mod tests {
         .tables();
 
         assert_eq!(tables, Some(vec![Table::Region, Table::Nation]));
-    }
-
-    #[tokio::test]
-    async fn column_encoding_without_tables_is_rejected() {
-        let cli = Cli::try_parse_from([
-            "tpchgen",
-            "parquet",
-            "--column-encoding",
-            "l_comment=PLAIN",
-            "--output-dir",
-            "/nonexistent-should-never-be-created",
-        ])
-        .unwrap();
-        let Some(Commands::Parquet(args)) = cli.command else {
-            panic!("expected parquet command")
-        };
-
-        let err = args.run().await.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("--column-encoding requires --tables"),
-            "{err}"
-        );
     }
 
     #[test]

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -1,11 +1,11 @@
 use super::generate::Sink;
-use super::output_plan::OutputPlanGenerator;
+use super::output_plan::{OutputPlanGenerator, ParquetWriteOptions};
 use super::plan::DEFAULT_PARQUET_ROW_GROUP_BYTES;
 use super::runner::PlanRunner;
 use super::statistics::WriteStatistics;
 use crate::parquet::IntoSize;
 use crate::progress::{no_op_progress_tracker, ProgressTracker};
-pub use ::parquet::basic::Compression;
+pub use ::parquet::basic::{Compression, Encoding};
 use log::info;
 use std::fmt::Display;
 use std::fs::File;
@@ -188,6 +188,8 @@ pub struct GeneratorConfig {
     pub num_threads: usize,
     /// Parquet compression format
     pub parquet_compression: Compression,
+    /// Per-column Parquet encodings (overrides writer defaults)
+    pub parquet_column_encodings: Vec<(String, Encoding)>,
     /// Target row group size in bytes for Parquet files
     pub parquet_row_group_bytes: i64,
     /// Number of partitions to generate (if None, generates a single file per table)
@@ -209,6 +211,7 @@ impl Default for GeneratorConfig {
             format: OutputFormat::Tbl,
             num_threads: num_cpus::get(),
             parquet_compression: Compression::SNAPPY,
+            parquet_column_encodings: Vec::new(),
             parquet_row_group_bytes: DEFAULT_PARQUET_ROW_GROUP_BYTES,
             parts: None,
             part: None,
@@ -263,7 +266,10 @@ impl TpchGenerator {
         let mut output_plan_generator = OutputPlanGenerator::new(
             config.format,
             config.scale_factor,
-            config.parquet_compression,
+            ParquetWriteOptions {
+                compression: config.parquet_compression,
+                column_encodings: config.parquet_column_encodings,
+            },
             config.parquet_row_group_bytes,
             config.stdout,
             config.output_dir,
@@ -345,6 +351,12 @@ impl TpchGeneratorBuilder {
     /// Set Parquet compression format (default: SNAPPY).
     pub fn with_parquet_compression(mut self, compression: Compression) -> Self {
         self.config.parquet_compression = compression;
+        self
+    }
+
+    /// Set per-column Parquet encodings (overrides writer defaults).
+    pub fn with_parquet_column_encodings(mut self, encodings: Vec<(String, Encoding)>) -> Self {
+        self.config.parquet_column_encodings = encodings;
         self
     }
 

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -231,14 +231,10 @@ impl Default for GeneratorConfig {
     }
 }
 
-/// Returns `table`'s Arrow schema. Does not generate any rows: `part` and
-/// `part_count` do not affect the schema, so this always uses `(1, 1)` (the
-/// whole table).
+/// Returns `table`'s Arrow schema. Does not generate any rows.
 ///
-/// Used by [`validate_column_encodings`] to catch a typo'd
-/// `--column-encoding` column name, and by [`column_encodings_for_table`]
-/// to find which requested encodings apply to a given table. A
-/// `--column-encoding` column usually belongs to one table, not all of them.
+/// `part` and `part_count` do not change the schema, so this always asks
+/// for `(1, 1)`.
 pub(super) fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
     match table {
         Table::Nation => NationArrow::new(NationGenerator::new(scale_factor, 1, 1)).schema(),
@@ -252,20 +248,19 @@ pub(super) fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
     }
 }
 
-/// Checks that each column in `encodings` exists in at least one of
-/// `tables`' schemas. Runs before any generation starts.
+/// Checks each column in `encodings` against every table in `tables`.
 ///
-/// A `--column-encoding` column usually applies to only some of the
-/// selected tables (e.g. `l_comment` exists only on `lineitem`).
-/// [`column_encodings_for_table`] applies each encoding where it matches
-/// and skips it elsewhere. This check only catches a column name that
-/// matches no table — almost always a typo.
+/// Rejects an encoding `reject_unsupported_encoding` always rejects.
+/// Rejects a column name that matches no table (almost always a typo). A
+/// column that matches only some tables is fine: [`column_encodings_for_table`]
+/// applies it there and skips it elsewhere.
 pub(super) fn validate_column_encodings(
     tables: &[Table],
     scale_factor: f64,
     encodings: &[(String, Encoding)],
 ) -> io::Result<()> {
-    for (col, _) in encodings {
+    for (col, enc) in encodings {
+        crate::parquet::reject_unsupported_encoding(*enc)?;
         let matches_any_table = tables.iter().any(|table| {
             table_schema(*table, scale_factor)
                 .fields()
@@ -281,9 +276,7 @@ pub(super) fn validate_column_encodings(
     Ok(())
 }
 
-/// Returns the encodings from `encodings` whose column exists in `table`'s
-/// schema. A column meant for a different table (e.g. `l_comment` while
-/// generating `orders`) is skipped, not rejected.
+/// Keeps only the encodings whose column exists in `table`'s schema.
 pub(super) fn column_encodings_for_table(
     table: Table,
     scale_factor: f64,
@@ -338,10 +331,21 @@ impl TpchGenerator {
             ]
         };
 
-        // Catch a --column-encoding column that matches no selected table
-        // (a typo) before scheduling any work. Each table only gets the
-        // encodings for its own columns (see `column_encodings_for_table`),
-        // so a column for a different table is not an error here.
+        // Warm up the distributions and text pool now, not on the first
+        // table. validate_column_encodings (below) builds a real generator
+        // per table to read its schema, and every generator also creates
+        // these statics. Warm up first, or the cost hides inside
+        // validation and this timing is wrong.
+        let start = Instant::now();
+        Distributions::static_default();
+        TextPool::get_or_init_default();
+        let elapsed = start.elapsed();
+        info!("Created static distributions and text pools in {elapsed:?}");
+
+        // Reject a --column-encoding column that matches no selected table
+        // (a typo) before any work starts. column_encodings_for_table
+        // (below) skips a column that only matches some tables, so that
+        // case is not an error.
         if let Some(encodings) = &config.parquet_column_encodings {
             validate_column_encodings(&tables, config.scale_factor, encodings)?;
         }
@@ -364,14 +368,6 @@ impl TpchGenerator {
             output_plan_generator.generate_plans(table, config.part, config.parts)?;
         }
         let output_plans = output_plan_generator.build();
-
-        // Force the creation of the distributions and text pool so it doesn't
-        // get charged to the first table.
-        let start = Instant::now();
-        Distributions::static_default();
-        TextPool::get_or_init_default();
-        let elapsed = start.elapsed();
-        info!("Created static distributions and text pools in {elapsed:?}");
 
         let runner = PlanRunner::new(output_plans, config.num_threads)
             .with_progress_tracker(progress_tracker);
@@ -536,30 +532,26 @@ mod tests {
     }
 
     #[test]
-    fn validate_column_encodings_accepts_a_column_present_on_just_one_selected_table() {
+    fn validate_column_encodings_accepts_a_column_present_on_just_one_table() {
         // l_comment exists only on lineitem, not orders.
-        // column_encodings_for_table skips it for orders, so this is fine.
         let tables = [Table::Lineitem, Table::Orders];
         let encodings = [("l_comment".to_string(), Encoding::PLAIN)];
         assert!(validate_column_encodings(&tables, 0.001, &encodings).is_ok());
     }
 
     #[test]
-    fn validate_column_encodings_rejects_a_typo_against_the_default_table_set() {
-        let tables = [
-            Table::Nation,
-            Table::Region,
-            Table::Part,
-            Table::Supplier,
-            Table::Partsupp,
-            Table::Customer,
-            Table::Orders,
-            Table::Lineitem,
-        ];
+    fn validate_column_encodings_rejects_a_typo() {
+        let tables = [Table::Lineitem, Table::Orders];
         let encodings = [("l_comment_typo".to_string(), Encoding::PLAIN)];
-        // Fails before any table starts generating.
         let err = validate_column_encodings(&tables, 0.001, &encodings).unwrap_err();
         assert!(err.to_string().contains("column 'l_comment_typo'"), "{err}");
+    }
+
+    #[test]
+    fn validate_column_encodings_rejects_dictionary_encoding() {
+        let tables = [Table::Lineitem];
+        let encodings = [("l_comment".to_string(), Encoding::PLAIN_DICTIONARY)];
+        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_err());
     }
 
     #[test]
@@ -571,10 +563,6 @@ mod tests {
         assert_eq!(
             column_encodings_for_table(Table::Lineitem, 0.001, &encodings),
             vec![("l_comment".to_string(), Encoding::PLAIN)]
-        );
-        assert_eq!(
-            column_encodings_for_table(Table::Orders, 0.001, &encodings),
-            vec![("o_comment".to_string(), Encoding::PLAIN)]
         );
         assert_eq!(
             column_encodings_for_table(Table::Nation, 0.001, &encodings),

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -231,11 +231,15 @@ impl Default for GeneratorConfig {
     }
 }
 
-/// Returns `table`'s Arrow schema without generating any rows: `part`/`part_count`
-/// don't affect the schema, so `(1, 1)` (the whole table, undivided) is used
-/// unconditionally. Used to validate `--column-encoding` column names against
-/// every selected table before scheduling any generation work.
-fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
+/// Returns `table`'s Arrow schema. Does not generate any rows: `part` and
+/// `part_count` do not affect the schema, so this always uses `(1, 1)` (the
+/// whole table).
+///
+/// Used by [`validate_column_encodings`] to catch a typo'd
+/// `--column-encoding` column name, and by [`column_encodings_for_table`]
+/// to find which requested encodings apply to a given table. A
+/// `--column-encoding` column usually belongs to one table, not all of them.
+pub(super) fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
     match table {
         Table::Nation => NationArrow::new(NationGenerator::new(scale_factor, 1, 1)).schema(),
         Table::Region => RegionArrow::new(RegionGenerator::new(scale_factor, 1, 1)).schema(),
@@ -248,38 +252,49 @@ fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
     }
 }
 
-/// Validates that every column referenced by `encodings` exists in every one
-/// of `tables`' schemas, before any generation starts.
+/// Checks that each column in `encodings` exists in at least one of
+/// `tables`' schemas. Runs before any generation starts.
 ///
-/// Failing here (rather than inside `generate_parquet`, once tables are
-/// already scheduled and some may be running concurrently) means a typo'd or
-/// table-specific column name can't leave one table's `.parquet` file fully
-/// written while a sibling table fails mid-run because it simply doesn't
-/// have that column.
-fn validate_column_encodings(
+/// A `--column-encoding` column usually applies to only some of the
+/// selected tables (e.g. `l_comment` exists only on `lineitem`).
+/// [`column_encodings_for_table`] applies each encoding where it matches
+/// and skips it elsewhere. This check only catches a column name that
+/// matches no table — almost always a typo.
+pub(super) fn validate_column_encodings(
     tables: &[Table],
     scale_factor: f64,
     encodings: &[(String, Encoding)],
 ) -> io::Result<()> {
     for (col, _) in encodings {
-        let missing: Vec<&str> = tables
-            .iter()
-            .filter(|table| {
-                !table_schema(**table, scale_factor)
-                    .fields()
-                    .iter()
-                    .any(|f| f.name() == col)
-            })
-            .map(|table| table.name())
-            .collect();
-        if !missing.is_empty() {
+        let matches_any_table = tables.iter().any(|table| {
+            table_schema(*table, scale_factor)
+                .fields()
+                .iter()
+                .any(|f| f.name() == col)
+        });
+        if !matches_any_table {
             return Err(io::Error::other(format!(
-                "column '{col}' for --column-encoding not found in table(s): {}",
-                missing.join(", ")
+                "column '{col}' for --column-encoding not found in any selected table"
             )));
         }
     }
     Ok(())
+}
+
+/// Returns the encodings from `encodings` whose column exists in `table`'s
+/// schema. A column meant for a different table (e.g. `l_comment` while
+/// generating `orders`) is skipped, not rejected.
+pub(super) fn column_encodings_for_table(
+    table: Table,
+    scale_factor: f64,
+    encodings: &[(String, Encoding)],
+) -> Vec<(String, Encoding)> {
+    let schema = table_schema(table, scale_factor);
+    encodings
+        .iter()
+        .filter(|(col, _)| schema.fields().iter().any(|f| f.name() == col))
+        .cloned()
+        .collect()
 }
 
 /// TPC-H data generator
@@ -323,11 +338,10 @@ impl TpchGenerator {
             ]
         };
 
-        // Validate --column-encoding columns against every selected table's
-        // schema up front: catching a missing column here means the command
-        // fails before any table starts writing, rather than after some
-        // tables have already completed while an unrelated table (that
-        // simply doesn't have the requested column) fails mid-run.
+        // Catch a --column-encoding column that matches no selected table
+        // (a typo) before scheduling any work. Each table only gets the
+        // encodings for its own columns (see `column_encodings_for_table`),
+        // so a column for a different table is not an error here.
         if let Some(encodings) = &config.parquet_column_encodings {
             validate_column_encodings(&tables, config.scale_factor, encodings)?;
         }
@@ -522,25 +536,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_column_encodings_accepts_a_column_present_in_every_selected_table() {
-        // Every TPC-H column name is prefixed by its own table (l_, o_, ...),
-        // so "present in every selected table" only ever means a single-table
-        // selection in practice; this exercises that path.
-        let tables = [Table::Lineitem];
-        let encodings = [("l_orderkey".to_string(), Encoding::PLAIN)];
-        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_ok());
-    }
-
-    #[test]
-    fn validate_column_encodings_rejects_a_column_missing_from_one_selected_table() {
-        // l_comment only exists on lineitem, not orders.
+    fn validate_column_encodings_accepts_a_column_present_on_just_one_selected_table() {
+        // l_comment exists only on lineitem, not orders.
+        // column_encodings_for_table skips it for orders, so this is fine.
         let tables = [Table::Lineitem, Table::Orders];
         let encodings = [("l_comment".to_string(), Encoding::PLAIN)];
-        let err = validate_column_encodings(&tables, 0.001, &encodings).unwrap_err();
-        let message = err.to_string();
-        assert!(message.contains("column 'l_comment'"), "{message}");
-        assert!(message.contains("orders"), "{message}");
-        assert!(!message.contains("lineitem"), "{message}");
+        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_ok());
     }
 
     #[test]
@@ -556,8 +557,29 @@ mod tests {
             Table::Lineitem,
         ];
         let encodings = [("l_comment_typo".to_string(), Encoding::PLAIN)];
-        // Fails before touching any table's actual generation.
-        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_err());
+        // Fails before any table starts generating.
+        let err = validate_column_encodings(&tables, 0.001, &encodings).unwrap_err();
+        assert!(err.to_string().contains("column 'l_comment_typo'"), "{err}");
+    }
+
+    #[test]
+    fn column_encodings_for_table_keeps_only_matching_columns() {
+        let encodings = [
+            ("l_comment".to_string(), Encoding::PLAIN),
+            ("o_comment".to_string(), Encoding::PLAIN),
+        ];
+        assert_eq!(
+            column_encodings_for_table(Table::Lineitem, 0.001, &encodings),
+            vec![("l_comment".to_string(), Encoding::PLAIN)]
+        );
+        assert_eq!(
+            column_encodings_for_table(Table::Orders, 0.001, &encodings),
+            vec![("o_comment".to_string(), Encoding::PLAIN)]
+        );
+        assert_eq!(
+            column_encodings_for_table(Table::Nation, 0.001, &encodings),
+            Vec::new()
+        );
     }
 
     #[tokio::test]

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -1,5 +1,5 @@
 use super::generate::Sink;
-use super::output_plan::{OutputPlanGenerator, ParquetWriteOptions};
+use super::output_plan::{OutputPlanGenerator, ParquetWriterOptions};
 use super::plan::DEFAULT_PARQUET_ROW_GROUP_BYTES;
 use super::runner::PlanRunner;
 use super::statistics::WriteStatistics;
@@ -266,7 +266,7 @@ impl TpchGenerator {
         let mut output_plan_generator = OutputPlanGenerator::new(
             config.format,
             config.scale_factor,
-            ParquetWriteOptions {
+            ParquetWriterOptions {
                 compression: config.parquet_compression,
                 column_encodings: config.parquet_column_encodings,
             },

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -6,6 +6,8 @@ use super::statistics::WriteStatistics;
 use crate::parquet::IntoSize;
 use crate::progress::{no_op_progress_tracker, ProgressTracker};
 pub use ::parquet::basic::{Compression, Encoding};
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatchReader;
 use log::info;
 use std::fmt::Display;
 use std::fs::File;
@@ -15,7 +17,15 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 use tpchgen::distribution::Distributions;
+use tpchgen::generators::{
+    CustomerGenerator, LineItemGenerator, NationGenerator, OrderGenerator, PartGenerator,
+    PartSuppGenerator, RegionGenerator, SupplierGenerator,
+};
 use tpchgen::text::TextPool;
+use tpchgen_arrow::{
+    CustomerArrow, LineItemArrow, NationArrow, OrderArrow, PartArrow, PartSuppArrow, RegionArrow,
+    SupplierArrow,
+};
 
 /// Wrapper around a buffer writer that counts the number of buffers and bytes written
 pub struct WriterSink<W: Write> {
@@ -221,6 +231,57 @@ impl Default for GeneratorConfig {
     }
 }
 
+/// Returns `table`'s Arrow schema without generating any rows: `part`/`part_count`
+/// don't affect the schema, so `(1, 1)` (the whole table, undivided) is used
+/// unconditionally. Used to validate `--column-encoding` column names against
+/// every selected table before scheduling any generation work.
+fn table_schema(table: Table, scale_factor: f64) -> SchemaRef {
+    match table {
+        Table::Nation => NationArrow::new(NationGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Region => RegionArrow::new(RegionGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Part => PartArrow::new(PartGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Supplier => SupplierArrow::new(SupplierGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Partsupp => PartSuppArrow::new(PartSuppGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Customer => CustomerArrow::new(CustomerGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Orders => OrderArrow::new(OrderGenerator::new(scale_factor, 1, 1)).schema(),
+        Table::Lineitem => LineItemArrow::new(LineItemGenerator::new(scale_factor, 1, 1)).schema(),
+    }
+}
+
+/// Validates that every column referenced by `encodings` exists in every one
+/// of `tables`' schemas, before any generation starts.
+///
+/// Failing here (rather than inside `generate_parquet`, once tables are
+/// already scheduled and some may be running concurrently) means a typo'd or
+/// table-specific column name can't leave one table's `.parquet` file fully
+/// written while a sibling table fails mid-run because it simply doesn't
+/// have that column.
+fn validate_column_encodings(
+    tables: &[Table],
+    scale_factor: f64,
+    encodings: &[(String, Encoding)],
+) -> io::Result<()> {
+    for (col, _) in encodings {
+        let missing: Vec<&str> = tables
+            .iter()
+            .filter(|table| {
+                !table_schema(**table, scale_factor)
+                    .fields()
+                    .iter()
+                    .any(|f| f.name() == col)
+            })
+            .map(|table| table.name())
+            .collect();
+        if !missing.is_empty() {
+            return Err(io::Error::other(format!(
+                "column '{col}' for --column-encoding not found in table(s): {}",
+                missing.join(", ")
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// TPC-H data generator
 ///
 /// The main entry point for generating TPC-H benchmark data.
@@ -261,6 +322,15 @@ impl TpchGenerator {
                 Table::Lineitem,
             ]
         };
+
+        // Validate --column-encoding columns against every selected table's
+        // schema up front: catching a missing column here means the command
+        // fails before any table starts writing, rather than after some
+        // tables have already completed while an unrelated table (that
+        // simply doesn't have the requested column) fails mid-run.
+        if let Some(encodings) = &config.parquet_column_encodings {
+            validate_column_encodings(&tables, config.scale_factor, encodings)?;
+        }
 
         // Determine what files to generate
         let mut output_plan_generator = OutputPlanGenerator::new(
@@ -449,6 +519,45 @@ mod tests {
         fn finish(&self) {
             self.finishes.fetch_add(1, Ordering::Relaxed);
         }
+    }
+
+    #[test]
+    fn validate_column_encodings_accepts_a_column_present_in_every_selected_table() {
+        // Every TPC-H column name is prefixed by its own table (l_, o_, ...),
+        // so "present in every selected table" only ever means a single-table
+        // selection in practice; this exercises that path.
+        let tables = [Table::Lineitem];
+        let encodings = [("l_orderkey".to_string(), Encoding::PLAIN)];
+        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_ok());
+    }
+
+    #[test]
+    fn validate_column_encodings_rejects_a_column_missing_from_one_selected_table() {
+        // l_comment only exists on lineitem, not orders.
+        let tables = [Table::Lineitem, Table::Orders];
+        let encodings = [("l_comment".to_string(), Encoding::PLAIN)];
+        let err = validate_column_encodings(&tables, 0.001, &encodings).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("column 'l_comment'"), "{message}");
+        assert!(message.contains("orders"), "{message}");
+        assert!(!message.contains("lineitem"), "{message}");
+    }
+
+    #[test]
+    fn validate_column_encodings_rejects_a_typo_against_the_default_table_set() {
+        let tables = [
+            Table::Nation,
+            Table::Region,
+            Table::Part,
+            Table::Supplier,
+            Table::Partsupp,
+            Table::Customer,
+            Table::Orders,
+            Table::Lineitem,
+        ];
+        let encodings = [("l_comment_typo".to_string(), Encoding::PLAIN)];
+        // Fails before touching any table's actual generation.
+        assert!(validate_column_encodings(&tables, 0.001, &encodings).is_err());
     }
 
     #[tokio::test]

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -189,7 +189,7 @@ pub struct GeneratorConfig {
     /// Parquet compression format
     pub parquet_compression: Compression,
     /// Per-column Parquet encodings (overrides writer defaults)
-    pub parquet_column_encodings: Vec<(String, Encoding)>,
+    pub parquet_column_encodings: Option<Vec<(String, Encoding)>>,
     /// Target row group size in bytes for Parquet files
     pub parquet_row_group_bytes: i64,
     /// Number of partitions to generate (if None, generates a single file per table)
@@ -211,7 +211,7 @@ impl Default for GeneratorConfig {
             format: OutputFormat::Tbl,
             num_threads: num_cpus::get(),
             parquet_compression: Compression::SNAPPY,
-            parquet_column_encodings: Vec::new(),
+            parquet_column_encodings: None,
             parquet_row_group_bytes: DEFAULT_PARQUET_ROW_GROUP_BYTES,
             parts: None,
             part: None,
@@ -355,7 +355,10 @@ impl TpchGeneratorBuilder {
     }
 
     /// Set per-column Parquet encodings (overrides writer defaults).
-    pub fn with_parquet_column_encodings(mut self, encodings: Vec<(String, Encoding)>) -> Self {
+    pub fn with_parquet_column_encodings(
+        mut self,
+        encodings: Option<Vec<(String, Encoding)>>,
+    ) -> Self {
         self.config.parquet_column_encodings = encodings;
         self
     }

--- a/tpcgen-cli/src/tpch_cli/output_plan.rs
+++ b/tpcgen-cli/src/tpch_cli/output_plan.rs
@@ -39,14 +39,14 @@ impl Display for OutputLocation {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParquetWriterOptions {
     pub compression: Compression,
-    pub column_encodings: Vec<(String, Encoding)>,
+    pub column_encodings: Option<Vec<(String, Encoding)>>,
 }
 
 impl Default for ParquetWriterOptions {
     fn default() -> Self {
         Self {
             compression: Compression::SNAPPY,
-            column_encodings: Vec::new(),
+            column_encodings: None,
         }
     }
 }
@@ -115,8 +115,8 @@ impl OutputPlan {
         self.parquet.compression
     }
 
-    pub fn parquet_column_encodings(&self) -> &[(String, Encoding)] {
-        &self.parquet.column_encodings
+    pub fn parquet_column_encodings(&self) -> Option<&[(String, Encoding)]> {
+        self.parquet.column_encodings.as_deref()
     }
 
     /// Return the number of chunks part(ition) count (the number of data chunks

--- a/tpcgen-cli/src/tpch_cli/output_plan.rs
+++ b/tpcgen-cli/src/tpch_cli/output_plan.rs
@@ -37,12 +37,12 @@ impl Display for OutputLocation {
 
 /// Parquet writer settings applied when generating parquet output.
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParquetWriteOptions {
+pub struct ParquetWriterOptions {
     pub compression: Compression,
     pub column_encodings: Vec<(String, Encoding)>,
 }
 
-impl Default for ParquetWriteOptions {
+impl Default for ParquetWriterOptions {
     fn default() -> Self {
         Self {
             compression: Compression::SNAPPY,
@@ -60,7 +60,7 @@ pub struct OutputPlan {
     scale_factor: f64,
     /// The output format (TODO don't depend back on something in main)
     output_format: OutputFormat,
-    parquet: ParquetWriteOptions,
+    parquet: ParquetWriterOptions,
     /// Where to output
     output_location: OutputLocation,
     /// Plan for generating the table
@@ -74,7 +74,7 @@ impl OutputPlan {
         table: Table,
         scale_factor: f64,
         output_format: OutputFormat,
-        parquet: ParquetWriteOptions,
+        parquet: ParquetWriterOptions,
         output_location: OutputLocation,
         generation_plan: GenerationPlan,
         csv_delimiter: char,
@@ -153,7 +153,7 @@ impl Display for OutputPlan {
 pub struct OutputPlanGenerator {
     format: OutputFormat,
     scale_factor: f64,
-    parquet: ParquetWriteOptions,
+    parquet: ParquetWriterOptions,
     parquet_row_group_bytes: i64,
     stdout: bool,
     output_dir: PathBuf,
@@ -169,7 +169,7 @@ impl OutputPlanGenerator {
     pub fn new(
         format: OutputFormat,
         scale_factor: f64,
-        parquet: ParquetWriteOptions,
+        parquet: ParquetWriterOptions,
         parquet_row_group_bytes: i64,
         stdout: bool,
         output_dir: PathBuf,

--- a/tpcgen-cli/src/tpch_cli/output_plan.rs
+++ b/tpcgen-cli/src/tpch_cli/output_plan.rs
@@ -50,6 +50,8 @@ impl Default for ParquetWriteOptions {
         }
     }
 }
+
+/// Describes an output partition (file) that will be generated
 #[derive(Debug, Clone, PartialEq)]
 pub struct OutputPlan {
     /// The table

--- a/tpcgen-cli/src/tpch_cli/output_plan.rs
+++ b/tpcgen-cli/src/tpch_cli/output_plan.rs
@@ -60,6 +60,7 @@ pub struct OutputPlan {
     scale_factor: f64,
     /// The output format (TODO don't depend back on something in main)
     output_format: OutputFormat,
+    /// Parquet writer options (compression and column encodings)
     parquet: ParquetWriterOptions,
     /// Where to output
     output_location: OutputLocation,

--- a/tpcgen-cli/src/tpch_cli/output_plan.rs
+++ b/tpcgen-cli/src/tpch_cli/output_plan.rs
@@ -5,7 +5,7 @@
 use crate::tpch_cli::plan::GenerationPlan;
 use crate::tpch_cli::{OutputFormat, Table};
 use log::debug;
-use parquet::basic::Compression;
+use parquet::basic::{Compression, Encoding};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::io;
@@ -35,7 +35,21 @@ impl Display for OutputLocation {
     }
 }
 
-/// Describes an output partition (file) that will be generated
+/// Parquet writer settings applied when generating parquet output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParquetWriteOptions {
+    pub compression: Compression,
+    pub column_encodings: Vec<(String, Encoding)>,
+}
+
+impl Default for ParquetWriteOptions {
+    fn default() -> Self {
+        Self {
+            compression: Compression::SNAPPY,
+            column_encodings: Vec::new(),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 pub struct OutputPlan {
     /// The table
@@ -44,8 +58,7 @@ pub struct OutputPlan {
     scale_factor: f64,
     /// The output format (TODO don't depend back on something in main)
     output_format: OutputFormat,
-    /// If the output is parquet, what compression level to use
-    parquet_compression: Compression,
+    parquet: ParquetWriteOptions,
     /// Where to output
     output_location: OutputLocation,
     /// Plan for generating the table
@@ -59,7 +72,7 @@ impl OutputPlan {
         table: Table,
         scale_factor: f64,
         output_format: OutputFormat,
-        parquet_compression: Compression,
+        parquet: ParquetWriteOptions,
         output_location: OutputLocation,
         generation_plan: GenerationPlan,
         csv_delimiter: char,
@@ -68,7 +81,7 @@ impl OutputPlan {
             table,
             scale_factor,
             output_format,
-            parquet_compression,
+            parquet,
             output_location,
             generation_plan,
             csv_delimiter,
@@ -97,7 +110,11 @@ impl OutputPlan {
 
     /// Return the parquet compression level for this partition
     pub fn parquet_compression(&self) -> Compression {
-        self.parquet_compression
+        self.parquet.compression
+    }
+
+    pub fn parquet_column_encodings(&self) -> &[(String, Encoding)] {
+        &self.parquet.column_encodings
     }
 
     /// Return the number of chunks part(ition) count (the number of data chunks
@@ -134,7 +151,7 @@ impl Display for OutputPlan {
 pub struct OutputPlanGenerator {
     format: OutputFormat,
     scale_factor: f64,
-    parquet_compression: Compression,
+    parquet: ParquetWriteOptions,
     parquet_row_group_bytes: i64,
     stdout: bool,
     output_dir: PathBuf,
@@ -150,7 +167,7 @@ impl OutputPlanGenerator {
     pub fn new(
         format: OutputFormat,
         scale_factor: f64,
-        parquet_compression: Compression,
+        parquet: ParquetWriteOptions,
         parquet_row_group_bytes: i64,
         stdout: bool,
         output_dir: PathBuf,
@@ -159,7 +176,7 @@ impl OutputPlanGenerator {
         Self {
             format,
             scale_factor,
-            parquet_compression,
+            parquet,
             parquet_row_group_bytes,
             stdout,
             output_dir,
@@ -217,7 +234,7 @@ impl OutputPlanGenerator {
             table,
             self.scale_factor,
             self.format,
-            self.parquet_compression,
+            self.parquet.clone(),
             output_location,
             generation_plan,
             self.csv_delimiter,

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -384,7 +384,7 @@ define_run!(
 mod tests {
     use super::*;
     use crate::progress::ProgressTracker;
-    use crate::tpch_cli::output_plan::ParquetWriteOptions;
+    use crate::tpch_cli::output_plan::ParquetWriterOptions;
     use crate::tpch_cli::{GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};
     use std::sync::{
         atomic::{AtomicU64, Ordering},
@@ -423,7 +423,7 @@ mod tests {
             Table::Lineitem,
             1.0,
             OutputFormat::Tbl,
-            ParquetWriteOptions::default(),
+            ParquetWriterOptions::default(),
             OutputLocation::File(output_path.clone()),
             generation_plan,
             ',',

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -194,7 +194,6 @@ where
     I::Item: RecordBatchReader + Send,
 {
     // Keep only the encodings for columns on this table.
-    // --column-encoding usually targets a few tables, not all of them.
     let column_encodings = plan
         .parquet_column_encodings()
         .map(|encodings| column_encodings_for_table(plan.table(), plan.scale_factor(), encodings));

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -200,6 +200,7 @@ where
                 sources,
                 num_threads,
                 plan.parquet_compression(),
+                plan.parquet_column_encodings(),
                 progress,
             )
             .await
@@ -219,6 +220,7 @@ where
                 sources,
                 num_threads,
                 plan.parquet_compression(),
+                plan.parquet_column_encodings(),
                 progress,
             )
             .await?;
@@ -382,7 +384,8 @@ define_run!(
 mod tests {
     use super::*;
     use crate::progress::ProgressTracker;
-    use crate::tpch_cli::{Compression, GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};
+    use crate::tpch_cli::output_plan::ParquetWriteOptions;
+    use crate::tpch_cli::{GenerationPlan, DEFAULT_PARQUET_ROW_GROUP_BYTES};
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -420,7 +423,7 @@ mod tests {
             Table::Lineitem,
             1.0,
             OutputFormat::Tbl,
-            Compression::SNAPPY,
+            ParquetWriteOptions::default(),
             OutputLocation::File(output_path.clone()),
             generation_plan,
             ',',

--- a/tpcgen-cli/src/tpch_cli/runner.rs
+++ b/tpcgen-cli/src/tpch_cli/runner.rs
@@ -7,6 +7,7 @@ use crate::temp_path::inprogress_path;
 use crate::tpch_cli::csv::*;
 use crate::tpch_cli::generate::generate_in_chunks;
 use crate::tpch_cli::generate::Source;
+use crate::tpch_cli::generator::column_encodings_for_table;
 use crate::tpch_cli::output_plan::{OutputLocation, OutputPlan};
 use crate::tpch_cli::tbl::*;
 use crate::tpch_cli::tbl::{LineItemTblSource, NationTblSource, RegionTblSource};
@@ -192,6 +193,13 @@ where
     I: Iterator + 'static,
     I::Item: RecordBatchReader + Send,
 {
+    // Keep only the encodings for columns on this table.
+    // --column-encoding usually targets a few tables, not all of them.
+    let column_encodings = plan
+        .parquet_column_encodings()
+        .map(|encodings| column_encodings_for_table(plan.table(), plan.scale_factor(), encodings));
+    let column_encodings = column_encodings.as_deref();
+
     match plan.output_location() {
         OutputLocation::Stdout => {
             let writer = BufWriter::with_capacity(32 * 1024 * 1024, io::stdout()); // 32MB buffer
@@ -200,7 +208,7 @@ where
                 sources,
                 num_threads,
                 plan.parquet_compression(),
-                plan.parquet_column_encodings(),
+                column_encodings,
                 progress,
             )
             .await
@@ -220,7 +228,7 @@ where
                 sources,
                 num_threads,
                 plan.parquet_compression(),
-                plan.parquet_column_encodings(),
+                column_encodings,
                 progress,
             )
             .await?;

--- a/tpcgen-cli/tests/cli_integration/test_helpers.rs
+++ b/tpcgen-cli/tests/cli_integration/test_helpers.rs
@@ -1,3 +1,4 @@
+use parquet::basic::Encoding;
 use parquet::file::metadata::ParquetMetaDataReader;
 use std::fs::File;
 use std::path::Path;
@@ -38,4 +39,19 @@ pub(crate) fn expect_row_group_sizes(output_dir: &Path, expected_row_groups: Vec
     let expected_row_groups = format!("{expected_row_groups:#?}");
     let actual_row_groups = format!("{actual_row_groups:#?}");
     assert_eq!(actual_row_groups, expected_row_groups);
+}
+
+pub(crate) fn column_encodings(path: &Path, column: &str) -> Vec<Encoding> {
+    let file = File::open(path).expect("Failed to open parquet file");
+    let mut metadata_reader = ParquetMetaDataReader::new();
+    metadata_reader.try_parse(&file).unwrap();
+    let metadata = metadata_reader.finish().unwrap();
+    for row_group in metadata.row_groups() {
+        for col in row_group.columns() {
+            if col.column_path().string() == column {
+                return col.encodings().collect();
+            }
+        }
+    }
+    panic!("column {column} not found in {}", path.display());
 }

--- a/tpcgen-cli/tests/cli_integration/test_helpers.rs
+++ b/tpcgen-cli/tests/cli_integration/test_helpers.rs
@@ -41,7 +41,7 @@ pub(crate) fn expect_row_group_sizes(output_dir: &Path, expected_row_groups: Vec
     assert_eq!(actual_row_groups, expected_row_groups);
 }
 
-pub(crate) fn column_encodings(path: &Path, column: &str) -> Vec<Encoding> {
+pub(crate) fn expect_column_encoding(path: &Path, column: &str, expected: Encoding) {
     let file = File::open(path).expect("Failed to open parquet file");
     let mut metadata_reader = ParquetMetaDataReader::new();
     metadata_reader.try_parse(&file).unwrap();
@@ -49,7 +49,12 @@ pub(crate) fn column_encodings(path: &Path, column: &str) -> Vec<Encoding> {
     for row_group in metadata.row_groups() {
         for col in row_group.columns() {
             if col.column_path().string() == column {
-                return col.encodings().collect();
+                let encodings: Vec<Encoding> = col.encodings().collect();
+                assert!(
+                    encodings.contains(&expected),
+                    "expected {column} to use {expected:?}, encodings: {encodings:?}"
+                );
+                return;
             }
         }
     }

--- a/tpcgen-cli/tests/cli_integration/test_helpers.rs
+++ b/tpcgen-cli/tests/cli_integration/test_helpers.rs
@@ -41,22 +41,32 @@ pub(crate) fn expect_row_group_sizes(output_dir: &Path, expected_row_groups: Vec
     assert_eq!(actual_row_groups, expected_row_groups);
 }
 
+/// Asserts `column` uses `expected` as one of its encodings in *every* row
+/// group of the file at `path` (not just the first row group that happens to
+/// contain it), so a regression that only affects later row groups (e.g. a
+/// dictionary-fallback threshold silently reverting to a different encoding
+/// partway through the file) doesn't go unnoticed.
 pub(crate) fn expect_column_encoding(path: &Path, column: &str, expected: Encoding) {
     let file = File::open(path).expect("Failed to open parquet file");
     let mut metadata_reader = ParquetMetaDataReader::new();
     metadata_reader.try_parse(&file).unwrap();
     let metadata = metadata_reader.finish().unwrap();
-    for row_group in metadata.row_groups() {
+    let mut found_in_any_row_group = false;
+    for (row_group_idx, row_group) in metadata.row_groups().iter().enumerate() {
         for col in row_group.columns() {
             if col.column_path().string() == column {
+                found_in_any_row_group = true;
                 let encodings: Vec<Encoding> = col.encodings().collect();
                 assert!(
                     encodings.contains(&expected),
-                    "expected {column} to use {expected:?}, encodings: {encodings:?}"
+                    "expected {column} to use {expected:?} in row group {row_group_idx}, encodings: {encodings:?}"
                 );
-                return;
             }
         }
     }
-    panic!("column {column} not found in {}", path.display());
+    assert!(
+        found_in_any_row_group,
+        "column {column} not found in {}",
+        path.display()
+    );
 }

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -1,11 +1,11 @@
-use super::test_helpers::{expect_row_group_sizes, RowGroups};
+use super::test_helpers::{column_encodings, expect_row_group_sizes, RowGroups};
 use arrow::array::RecordBatch;
 use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType, TimeUnit};
 use arrow::record_batch::RecordBatchReader;
 use assert_cmd::cargo::cargo_bin_cmd;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use parquet::basic::Compression;
+use parquet::basic::{Compression, Encoding};
 use parquet::file::metadata::ParquetMetaDataReader;
 use std::collections::BTreeSet;
 use std::fs;
@@ -238,6 +238,59 @@ fn test_tpcgen_cli_tpcds_parquet_compression() {
             assert_eq!(column.compression(), Compression::UNCOMPRESSED);
         }
     }
+}
+
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_column_encoding() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("reason")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("r_reason_description=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
+        .success();
+
+    let path = temp_dir.path().join("reason.parquet");
+    let desc_encodings = column_encodings(&path, "r_reason_description");
+    let sk_encodings = column_encodings(&path, "r_reason_sk");
+
+    assert!(
+        desc_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        "r_reason_description encodings: {desc_encodings:?}"
+    );
+    assert!(
+        !sk_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        "r_reason_sk encodings: {sk_encodings:?}"
+    );
+}
+
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_rejects_invalid_column_encoding() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("r_reason_description=NOT_AN_ENCODING")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("--column-encoding"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -287,6 +287,42 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_invalid_column_encoding() {
     );
 }
 
+/// `--column-encoding` naming a column that only exists on some of the
+/// selected tables must fail before any table is written, not partway
+/// through after another table has already completed.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_column_encoding_missing_from_one_table_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    // r_reason_description only exists on reason, not item.
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("reason,item")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("r_reason_description=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("column 'r_reason_description'") && stderr.contains("item"),
+        "unexpected stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_dir(temp_dir.path())
+            .expect("Failed to read output directory")
+            .count(),
+        0,
+        "expected no output files when validation fails before generation starts"
+    );
+}
+
 #[test]
 fn test_tpcgen_cli_tpcds_parquet_row_group_size_1mb() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -287,15 +287,15 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_invalid_column_encoding() {
     );
 }
 
-/// `--column-encoding` naming a column that only exists on some of the
-/// selected tables must fail before any table is written, not partway
-/// through after another table has already completed.
+/// A `--column-encoding` column that exists on only some selected tables
+/// applies there and is skipped elsewhere. Selecting tables that do not
+/// share every named column is not an error.
 #[test]
-fn test_tpcgen_cli_tpcds_parquet_column_encoding_missing_from_one_table_fails_before_any_output() {
+fn test_tpcgen_cli_tpcds_parquet_column_encoding_applies_only_where_the_column_exists() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
     // r_reason_description only exists on reason, not item.
-    let assert = cargo_bin_cmd!("tpcgen-cli")
+    cargo_bin_cmd!("tpcgen-cli")
         .arg("tpcds")
         .arg("parquet")
         .arg("--scale-factor")
@@ -307,11 +307,43 @@ fn test_tpcgen_cli_tpcds_parquet_column_encoding_missing_from_one_table_fails_be
         .arg("--column-encoding")
         .arg("r_reason_description=DELTA_LENGTH_BYTE_ARRAY")
         .assert()
+        .success();
+
+    let reason_path = temp_dir.path().join("reason.parquet");
+    expect_column_encoding(
+        &reason_path,
+        "r_reason_description",
+        Encoding::DELTA_LENGTH_BYTE_ARRAY,
+    );
+    assert!(
+        temp_dir.path().join("item.parquet").exists(),
+        "expected item.parquet to still be generated, just without r_reason_description applied to it"
+    );
+}
+
+/// A `--column-encoding` column that matches no selected table (a typo)
+/// must fail before any table is written.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_column_encoding_typo_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("reason,item")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("r_reason_description_typo=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
         .failure();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("column 'r_reason_description'") && stderr.contains("item"),
+        stderr.contains("column 'r_reason_description_typo'"),
         "unexpected stderr: {stderr}"
     );
     assert_eq!(

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -355,6 +355,43 @@ fn test_tpcgen_cli_tpcds_parquet_column_encoding_typo_fails_before_any_output() 
     );
 }
 
+/// PLAIN_DICTIONARY, RLE_DICTIONARY, and BIT_PACKED are always rejected.
+/// This must fail before any table is written, same as a typo, even when
+/// the column exists on only one of the selected tables.
+#[test]
+fn test_tpcgen_cli_tpcds_parquet_dictionary_encoding_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    // r_reason_description only exists on reason. This must still fail up
+    // front, before either table is scheduled.
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .arg("tpcds")
+        .arg("parquet")
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("reason,item")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("r_reason_description=PLAIN_DICTIONARY")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("cannot be set with --column-encoding"),
+        "unexpected stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_dir(temp_dir.path())
+            .expect("Failed to read output directory")
+            .count(),
+        0,
+        "expected no output files when validation fails before generation starts"
+    );
+}
+
 #[test]
 fn test_tpcgen_cli_tpcds_parquet_row_group_size_1mb() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -1,4 +1,4 @@
-use super::test_helpers::{column_encodings, expect_row_group_sizes, RowGroups};
+use super::test_helpers::{expect_column_encoding, expect_row_group_sizes, RowGroups};
 use arrow::array::RecordBatch;
 use arrow::compute::concat_batches;
 use arrow::datatypes::{DataType, TimeUnit};
@@ -259,16 +259,10 @@ fn test_tpcgen_cli_tpcds_parquet_column_encoding() {
         .success();
 
     let path = temp_dir.path().join("reason.parquet");
-    let desc_encodings = column_encodings(&path, "r_reason_description");
-    let sk_encodings = column_encodings(&path, "r_reason_sk");
-
-    assert!(
-        desc_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
-        "r_reason_description encodings: {desc_encodings:?}"
-    );
-    assert!(
-        !sk_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
-        "r_reason_sk encodings: {sk_encodings:?}"
+    expect_column_encoding(
+        &path,
+        "r_reason_description",
+        Encoding::DELTA_LENGTH_BYTE_ARRAY,
     );
 }
 

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -1,4 +1,4 @@
-use super::test_helpers::{column_encodings, expect_row_group_sizes, RowGroups};
+use super::test_helpers::{expect_column_encoding, expect_row_group_sizes, RowGroups};
 use arrow::record_batch::RecordBatchReader;
 use assert_cmd::cargo::cargo_bin_cmd;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};
@@ -70,22 +70,8 @@ fn test_tpcgen_cli_tpch_parquet_column_encoding() {
         .success();
 
     let path = temp_dir.path().join("lineitem.parquet");
-    let comment_encodings = column_encodings(&path, "l_comment");
-    let shipinstruct_encodings = column_encodings(&path, "l_shipinstruct");
-    let orderkey_encodings = column_encodings(&path, "l_orderkey");
-
-    assert!(
-        comment_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
-        "l_comment encodings: {comment_encodings:?}"
-    );
-    assert!(
-        shipinstruct_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
-        "l_shipinstruct encodings: {shipinstruct_encodings:?}"
-    );
-    assert!(
-        !orderkey_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
-        "l_orderkey encodings: {orderkey_encodings:?}"
-    );
+    expect_column_encoding(&path, "l_comment", Encoding::DELTA_LENGTH_BYTE_ARRAY);
+    expect_column_encoding(&path, "l_shipinstruct", Encoding::DELTA_LENGTH_BYTE_ARRAY);
 }
 
 #[test]

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -126,6 +126,42 @@ fn test_tpcgen_cli_tpch_parquet_rejects_invalid_column_encoding() {
     }
 }
 
+/// `--column-encoding` naming a column that only exists on some of the
+/// selected tables must fail before any table is written, not partway
+/// through after another table has already completed.
+#[test]
+fn test_tpcgen_cli_tpch_parquet_column_encoding_missing_from_one_table_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    // l_comment only exists on lineitem, not orders.
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("lineitem,orders")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--no-progress")
+        .arg("--column-encoding")
+        .arg("l_comment=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("column 'l_comment'") && stderr.contains("orders"),
+        "unexpected stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_dir(temp_dir.path())
+            .expect("Failed to read output directory")
+            .count(),
+        0,
+        "expected no output files when validation fails before generation starts"
+    );
+}
+
 /// Repeated TPC-H table selections should schedule each table once.
 #[test]
 fn test_tpcgen_cli_tpch_deduplicates_selected_tables() {

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -194,6 +194,43 @@ fn test_tpcgen_cli_tpch_parquet_column_encoding_typo_fails_before_any_output() {
     );
 }
 
+/// PLAIN_DICTIONARY, RLE_DICTIONARY, and BIT_PACKED are always rejected.
+/// This must fail before any table is written, same as a typo, even when
+/// the column exists on only one of the selected tables.
+#[test]
+fn test_tpcgen_cli_tpch_parquet_dictionary_encoding_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    // l_comment only exists on lineitem. This must still fail up front,
+    // before either table is scheduled.
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("lineitem,orders")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--no-progress")
+        .arg("--column-encoding")
+        .arg("l_comment=PLAIN_DICTIONARY")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("cannot be set with --column-encoding"),
+        "unexpected stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_dir(temp_dir.path())
+            .expect("Failed to read output directory")
+            .count(),
+        0,
+        "expected no output files when validation fails before generation starts"
+    );
+}
+
 /// Repeated TPC-H table selections should schedule each table once.
 #[test]
 fn test_tpcgen_cli_tpch_deduplicates_selected_tables() {

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -1,7 +1,8 @@
-use super::test_helpers::{expect_row_group_sizes, RowGroups};
+use super::test_helpers::{column_encodings, expect_row_group_sizes, RowGroups};
 use arrow::record_batch::RecordBatchReader;
 use assert_cmd::cargo::cargo_bin_cmd;
 use parquet::arrow::arrow_reader::{ArrowReaderOptions, ParquetRecordBatchReaderBuilder};
+use parquet::basic::Encoding;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
@@ -48,6 +49,78 @@ fn test_tpcgen_cli_tpch_command_forms() {
             form.join(" ")
         );
     }
+}
+
+#[test]
+fn test_tpcgen_cli_tpch_parquet_column_encoding() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--scale-factor")
+        .arg("0.001")
+        .arg("--tables")
+        .arg("lineitem")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--no-progress")
+        .arg("--column-encoding")
+        .arg("l_comment=DELTA_LENGTH_BYTE_ARRAY,l_shipinstruct=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
+        .success();
+
+    let path = temp_dir.path().join("lineitem.parquet");
+    let comment_encodings = column_encodings(&path, "l_comment");
+    let shipinstruct_encodings = column_encodings(&path, "l_shipinstruct");
+    let orderkey_encodings = column_encodings(&path, "l_orderkey");
+
+    assert!(
+        comment_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        "l_comment encodings: {comment_encodings:?}"
+    );
+    assert!(
+        shipinstruct_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        "l_shipinstruct encodings: {shipinstruct_encodings:?}"
+    );
+    assert!(
+        !orderkey_encodings.contains(&Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        "l_orderkey encodings: {orderkey_encodings:?}"
+    );
+}
+
+#[test]
+fn test_tpcgen_cli_tpch_parquet_rejects_invalid_column_encoding() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("l_comment=NOT_AN_ENCODING")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("invalid value") && stderr.contains("--column-encoding"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--column-encoding")
+        .arg("nocolonequal")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("expected COLUMN=ENCODING"),
+        "unexpected stderr: {stderr}"
+    );
 }
 
 /// Repeated TPC-H table selections should schedule each table once.

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -126,15 +126,15 @@ fn test_tpcgen_cli_tpch_parquet_rejects_invalid_column_encoding() {
     }
 }
 
-/// `--column-encoding` naming a column that only exists on some of the
-/// selected tables must fail before any table is written, not partway
-/// through after another table has already completed.
+/// A `--column-encoding` column that exists on only some selected tables
+/// applies there and is skipped elsewhere. Selecting tables that do not
+/// share every named column is not an error.
 #[test]
-fn test_tpcgen_cli_tpch_parquet_column_encoding_missing_from_one_table_fails_before_any_output() {
+fn test_tpcgen_cli_tpch_parquet_column_encoding_applies_only_where_the_column_exists() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
 
     // l_comment only exists on lineitem, not orders.
-    let assert = cargo_bin_cmd!("tpcgen-cli")
+    cargo_bin_cmd!("tpcgen-cli")
         .args(["tpch", "parquet"])
         .arg("--scale-factor")
         .arg("0.01")
@@ -146,11 +146,43 @@ fn test_tpcgen_cli_tpch_parquet_column_encoding_missing_from_one_table_fails_bef
         .arg("--column-encoding")
         .arg("l_comment=DELTA_LENGTH_BYTE_ARRAY")
         .assert()
+        .success();
+
+    let lineitem_path = temp_dir.path().join("lineitem.parquet");
+    expect_column_encoding(
+        &lineitem_path,
+        "l_comment",
+        Encoding::DELTA_LENGTH_BYTE_ARRAY,
+    );
+    assert!(
+        temp_dir.path().join("orders.parquet").exists(),
+        "expected orders.parquet to still be generated, just without l_comment applied to it"
+    );
+}
+
+/// A `--column-encoding` column that matches no selected table (a typo)
+/// must fail before any table is written.
+#[test]
+fn test_tpcgen_cli_tpch_parquet_column_encoding_typo_fails_before_any_output() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    let assert = cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet"])
+        .arg("--scale-factor")
+        .arg("0.01")
+        .arg("--tables")
+        .arg("lineitem,orders")
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .arg("--no-progress")
+        .arg("--column-encoding")
+        .arg("l_comment_typo=DELTA_LENGTH_BYTE_ARRAY")
+        .assert()
         .failure();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("column 'l_comment'") && stderr.contains("orders"),
+        stderr.contains("column 'l_comment_typo'"),
         "unexpected stderr: {stderr}"
     );
     assert_eq!(

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -65,7 +65,7 @@ fn test_tpcgen_cli_tpch_parquet_column_encoding() {
         .arg(temp_dir.path())
         .arg("--no-progress")
         .arg("--column-encoding")
-        .arg("l_comment=DELTA_LENGTH_BYTE_ARRAY,l_shipinstruct=DELTA_LENGTH_BYTE_ARRAY")
+        .arg("l_comment=DELTA_LENGTH_BYTE_ARRAY, l_shipinstruct = delta_length_byte_array ")
         .assert()
         .success();
 
@@ -121,6 +121,23 @@ fn test_tpcgen_cli_tpch_parquet_rejects_invalid_column_encoding() {
         stderr.contains("expected COLUMN=ENCODING"),
         "unexpected stderr: {stderr}"
     );
+
+    for invalid in ["=PLAIN", "l_comment="] {
+        let assert = cargo_bin_cmd!("tpcgen-cli")
+            .args(["tpch", "parquet"])
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .arg("--column-encoding")
+            .arg(invalid)
+            .assert()
+            .failure();
+
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(
+            stderr.contains("expected COLUMN=ENCODING"),
+            "unexpected stderr for {invalid}: {stderr}"
+        );
+    }
 }
 
 /// Repeated TPC-H table selections should schedule each table once.

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -57,6 +57,9 @@ tpchgen-cli -s 10 --output-dir sf10
 # (220GB, 20 files, 6B lineitem rows, 3.5 minutes on a modern laptop)
 tpchgen-cli parquet -s 1000 --tables lineitem --parts 20 --row-group-bytes=100000000 --output-dir sf1000
 
+# Per-column encodings (overrides Parquet writer defaults for named columns)
+tpchgen-cli parquet -s 1 --tables lineitem --column-encoding=l_comment=DELTA_LENGTH_BYTE_ARRAY,l_shipinstruct=DELTA_LENGTH_BYTE_ARRAY
+
 # Scale Factor 10, partition 2 and 3 of 10 in sf10 directory
 #
 # partitioned/


### PR DESCRIPTION
closes #237

Adds `--column-encoding` flag to the tpchgen-cli CLI with `parquet` to support a comma delimited series of per-column encodings when generating parquet data.

Note: I am not super proficient in Rust so this PR was heavily agent generated.

Also I'm a colleague of @Matt711, who raised this issue, and we're very interested in using this feature

