### PR TITLE
Update project references after repository move

### DIFF
--- a/.github/workflows/ci_typos.yml
+++ b/.github/workflows/ci_typos.yml
@@ -1,4 +1,4 @@
-# Copyright The tpchgen-rs Authors
+# Copyright The tpcgen-rs Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to tpchgen-rs
+# Contributing to tpcgen-rs
 
 We want to make contributing to this project as easy and transparent as
 possible, if you have suggestions to improve the contributions guide feel
@@ -56,5 +56,5 @@ hyperfine --runs 5 \
 
 ## License
 
-By contributing to tpchgen-rs, you agree that your contributions will be licensed
+By contributing to tpcgen-rs, you agree that your contributions will be licensed
 under the LICENSE file in the root directory of this source tree.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ resolver = "2"
 [workspace.package]
 authors = ["clflushopt", "alamb"]
 edition = "2021"
-homepage = "https://github.com/clflushopt/tpchgen-rs"
+homepage = "https://github.com/datafusion-contrib/tpcgen-rs"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/clflushopt/tpchgen-rs"
+repository = "https://github.com/datafusion-contrib/tpcgen-rs"
 version = "3.0.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# tpchgen-rs
+# tpcgen-rs
 
 [![Apache licensed][license-badge]][license-url]
 [![Build Status][actions-badge]][actions-url]
 
 [license-badge]: https://img.shields.io/badge/license-Apache%20v2-blue.svg
-[license-url]: https://github.com/clflushopt/tpchgen-rs/blob/main/LICENSE
-[actions-badge]: https://github.com/clflushopt/tpchgen-rs/actions/workflows/rust.yml/badge.svg
-[actions-url]: https://github.com/clflushopt/tpchgen-rs/actions?query=branch%3Amain
+[license-url]: https://github.com/datafusion-contrib/tpcgen-rs/blob/main/LICENSE
+[actions-badge]: https://github.com/datafusion-contrib/tpcgen-rs/actions/workflows/rust.yml/badge.svg
+[actions-url]: https://github.com/datafusion-contrib/tpcgen-rs/actions?query=branch%3Amain
 
 Blazing fast [TPCH] benchmark data generator, in pure Rust with zero dependencies.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # tpcgen-rs
 
+> [!NOTE]
+> Originally written by [@clflushopt](https://github.com/clflushopt) at
+> [`clflushopt/tpchgen-rs`](https://github.com/clflushopt/tpchgen-rs).
+> The project is now maintained at
+> [`datafusion-contrib/tpcgen-rs`](https://github.com/datafusion-contrib/tpcgen-rs).
+
 [![Apache licensed][license-badge]][license-url]
 [![Build Status][actions-badge]][actions-url]
 

--- a/benchmarks/BENCHMARKS.md
+++ b/benchmarks/BENCHMARKS.md
@@ -25,9 +25,9 @@ tpchgen-cli parquet -s 100 --stdout | pv -arb > /dev/null
 
 ![Parquet Generation Performance](../parquet-performance.png)
 
-See [tpchgen-rs performance Spreadsheet] for more details.
+See [tpcgen-rs performance Spreadsheet] for more details.
 
-[tpchgen-rs performance Spreadsheet]: https://docs.google.com/spreadsheets/d/14qTHR5zgqXq4BkhO1IUw2BPwBUIOqMXLZ2fUyOaPflI/edit?gid=0#gid=0
+[tpcgen-rs performance Spreadsheet]: https://docs.google.com/spreadsheets/d/14qTHR5zgqXq4BkhO1IUw2BPwBUIOqMXLZ2fUyOaPflI/edit?gid=0#gid=0
 
 [Apache Parquet](https://parquet.apache.org/) is a columnar storage file format
 that is optimized for use with big data processing frameworks. It is widely used
@@ -245,13 +245,12 @@ dd if=/dev/zero of=/data/test1.img bs=1G count=10 oflag=dsync
 # 10737418240 bytes (11 GB, 10 GiB) copied, 13.179 s, 815 MB/s
 ```
 
-## install `tpchgen-rs`
+## install `tpcgen-rs`
 ```shell
 cd /data
-git clone git@github.com:clflushopt/tpchgen-rs.git
-cd tpchgen-rs
+git clone git@github.com:datafusion-contrib/tpcgen-rs.git
+cd tpcgen-rs
 cargo install --path tpchgen-cli
 ```
-
 
 

--- a/tpcdsgen-arrow/Cargo.toml
+++ b/tpcdsgen-arrow/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["clflushopt", "alamb"]
 description = "TPC-DS data generator into Apache Arrow format"
-repository = "https://github.com/clflushopt/tpchgen-rs"
+repository = { workspace = true }
 readme = "README.md"
 license = "Apache-2.0"
 

--- a/tpcdsgen-arrow/README.md
+++ b/tpcdsgen-arrow/README.md
@@ -22,4 +22,4 @@ This crate ensures correct results using two methods.
 
 Please see [CONTRIBUTING.md] for more information on how to contribute to this project.
 
-[CONTRIBUTING.md]: https://github.com/clflushopt/tpchgen-rs/blob/main/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/datafusion-contrib/tpcgen-rs/blob/main/CONTRIBUTING.md

--- a/tpcdsgen/Cargo.toml
+++ b/tpcdsgen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tpcdsgen"
 authors = ["clflushopt", "alamb"]
 description = "TPC-DS data generation library."
-repository = "https://github.com/clflushopt/tpchgen-rs"
+repository = { workspace = true }
 version = "0.1.0"
 edition = "2021"
 license = { workspace = true }

--- a/tpcgen-cli/bin/tpcgen_cli.rs
+++ b/tpcgen-cli/bin/tpcgen_cli.rs
@@ -13,7 +13,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 #[command(
     about = "TPC-H and TPC-DS data generator",
     long_about = r#"
-TPC-H and TPC-DS data generator (https://github.com/clflushopt/tpchgen-rs)
+TPC-H and TPC-DS data generator (https://github.com/datafusion-contrib/tpcgen-rs)
 
 Examples
 

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
     about = "TPC-H Data Generator",
     // --help output
     long_about = r#"
-TPCH Data Generator (https://github.com/clflushopt/tpchgen-rs)
+TPCH Data Generator (https://github.com/datafusion-contrib/tpcgen-rs)
 
 By default each table is written to a single file named <output_dir>/<table>.<format>
 

--- a/tpchgen-arrow/Cargo.toml
+++ b/tpchgen-arrow/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.0.0"
 edition = "2024"
 authors = ["clflushopt", "alamb"]
 description = "TPC-H data generator into Apache Arrow format"
-repository = "https://github.com/clflushopt/tpchgen-rs"
+repository = { workspace = true }
 readme = "README.md"
 license = "Apache-2.0"
 

--- a/tpchgen-arrow/README.md
+++ b/tpchgen-arrow/README.md
@@ -21,4 +21,4 @@ This crate ensures correct results using two methods.
 
 Please see [CONTRIBUTING.md] for more information on how to contribute to this project.
 
-[CONTRIBUTING.md]: https://github.com/clflushopt/tpchgen-rs/blob/main/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/datafusion-contrib/tpcgen-rs/blob/main/CONTRIBUTING.md

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -8,9 +8,9 @@ of (`duckdb`). On a 2023 Mac M3 Max laptop, it easily generates data faster than
 can be written to SSD. See [BENCHMARKS.md] for more details on performance and
 benchmarking.
 
-[BENCHMARKS.md]: https://github.com/clflushopt/tpchgen-rs/blob/main/benchmarks/BENCHMARKS.md
+[BENCHMARKS.md]: https://github.com/datafusion-contrib/tpcgen-rs/blob/main/benchmarks/BENCHMARKS.md
 
-* See the tpchgen [README.md](https://github.com/clflushopt/tpchgen-rs) for
+* See the tpchgen [README.md](https://github.com/datafusion-contrib/tpcgen-rs) for
 project details
 * Watch this [awesome demo](https://www.youtube.com/watch?v=UYIC57hlL14)  by
 [@alamb](https://github.com/alamb) to see `tpchgen-cli` in action
@@ -104,4 +104,3 @@ tpchgen-cli --format=parquet --parquet-compression=ZSTD(1) -s 10
 # After
 tpchgen-cli parquet --compression=ZSTD(1) -s 10
 ```
-

--- a/tpchgen/Cargo.toml
+++ b/tpchgen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tpchgen"
 authors = ["clflushopt", "alamb"]
 description = "Blazing fast pure Rust no dependency TPC-H data generation library."
-repository = "https://github.com/clflushopt/tpchgen-rs"
+repository = { workspace = true }
 readme = "README.md"
 version = { workspace = true }
 edition = { workspace = true }

--- a/tpchgen/README.md
+++ b/tpchgen/README.md
@@ -4,5 +4,5 @@ This crate provides the core data generator logic for TPC-H. It has no
 dependencies and is easy to embed in any other Rust projects.
 
 See the [docs.rs page](https://docs.rs/tpchgen/latest/tpchgen/) for API and the
-the tpchgen [README.md](https://github.com/clflushopt/tpchgen-rs) for more
+the tpchgen [README.md](https://github.com/datafusion-contrib/tpcgen-rs) for more
 information on the project.

--- a/tpchgen/src/lib.rs
+++ b/tpchgen/src/lib.rs
@@ -49,7 +49,7 @@
 //! generation logic.
 //!
 //! If you want an easy way to generate the TPC-H dataset for usage with external
-//! see the [`tpchgen-cli`](https://github.com/alamb/tpchgen-rs/tree/main/tpchgen-cli)
+//! see the [`tpchgen-cli`](https://github.com/datafusion-contrib/tpcgen-rs/tree/main/tpchgen-cli)
 //! tool instead.
 pub mod csv;
 pub mod dates;


### PR DESCRIPTION
## Summary

Updates project references following the move to `datafusion-contrib/tpcgen-rs`.

- Rename repository-level references to `tpcgen-rs`
- Update documentation, badges, CLI help, and Cargo metadata
- Credit the original author
- Preserve existing `tpchgen*` crate and binary names

## Review notes

The changes are split for separate review:

1. [`a4d2751`](https://github.com/kevinjqliu/tpchgen-rs/commit/a4d2751) — Update references for the repository rename
2. [`6bdca48`](https://github.com/kevinjqliu/tpchgen-rs/commit/6bdca48) — Inherit repository metadata from the workspace
3. [`f159081`](https://github.com/kevinjqliu/tpchgen-rs/commit/f159081) — Add a note in README to credit [`clflushopt`](https://github.com/clflushopt) for the original repo

Closes #404