### PR TITLE
Publish crates.io packages as a workspace

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,26 +13,13 @@ jobs:
     permissions:
       contents: read
       id-token: write     # Required for OIDC token exchange
-    strategy:
-      # Publish package one by one instead of flooding the registry
-      max-parallel: 1
-      matrix:
-        # Order here is sensitive, as it will be used to determine the order of publishing
-        package:
-          - "tpchgen"
-          - "tpcdsgen"
-          - "tpchgen-arrow"
-          - "tpcdsgen-arrow"
-          - "tpcgen-cli"
-          - "tpchgen-cli"
     steps:
       - uses: actions/checkout@v7
 
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
-      - name: Publish ${{ matrix.package }}
-        working-directory: ${{ matrix.package }}
-        run: cargo publish
+      - name: Publish workspace
+        run: cargo publish --workspace
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

Replace the per-crate publishing matrix with `cargo publish --workspace`.

## Why

- Cargo determines package and dependency order from workspace manifests.
- Future publishable workspace members require no workflow changes.
- Matches our lockstep release process: every artifact is version-bumped before publishing.

## Dry run

1. Temporarily bumped TPC-H artifacts from `3.0.0` to `3.0.1` and TPC-DS/unified artifacts from `0.1.0` to `0.1.1`.
2. Updated all internal dependency constraints to the temporary versions.
3. Ran `cargo publish --workspace --dry-run --allow-dirty`.
4. Confirmed all six crates packaged and compiled, with dependencies ordered before dependents.
5. Restored the temporary version changes.