### PR TITLE
ci: audit Rust dependencies

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,30 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@6cd13508893c0e7eab5f273c2575d3859bd7229a # v2.86.6
+        with:
+          tool: cargo-audit@0.22.2
+      - name: Audit Rust dependencies
+        run: cargo audit


### PR DESCRIPTION
## Summary

Add a `cargo audit` workflow to catch vulnerable dependency updates and newly published advisories. It runs for pull requests, pushes to `main`, weekly schedules, and manual dispatches using `cargo-audit` 0.22.2 with SHA-pinned actions, read-only permissions, and a ten-minute timeout.

The workflow audits `Cargo.lock` when present; otherwise, `cargo audit` generates the dependency resolution.

## Validation

- `actionlint .github/workflows/audit.yml`
- `cargo audit` scanned 200 dependencies with no vulnerabilities