### PR TITLE
fix: wrap TPC-H long RNG seed advance

### DIFF
--- a/tpchgen/src/generators.rs
+++ b/tpchgen/src/generators.rs
@@ -2511,6 +2511,15 @@ mod tests {
     }
 
     #[test]
+    fn test_large_scale_partitioned_line_item_generation() {
+        let line_item_count = LineItemGenerator::new(100_000.0, 1, 1_000_000_000)
+            .iter()
+            .count();
+
+        assert_eq!(line_item_count, 586);
+    }
+
+    #[test]
     fn check_iter_static_lifetimes() {
         // Lifetimes of iterators should be independent of the generator that
         // created it. This test case won't compile if that's not the case.

--- a/tpchgen/src/random.rs
+++ b/tpchgen/src/random.rs
@@ -166,7 +166,7 @@ impl RowRandomLong {
 
         while count > 0 {
             if count % 2 != 0 {
-                self.seed = (multiplier * self.seed) % Self::MODULUS_32;
+                self.seed = multiplier.wrapping_mul(self.seed) % Self::MODULUS_32;
             }
 
             // Integer division, truncates


### PR DESCRIPTION
## Summary

- Use wrapping multiplication when advancing the 64-bit TPC-H RNG through its 32-bit seed path.
- Add a boundary regression test.

## Reproduction

```sh
RUST_BACKTRACE=full \
RUSTFLAGS="-C overflow-checks=yes -C debug-assertions=yes" \
cargo run --locked --release -p tpcgen-cli --bin tpcgen-cli -- \
  tpch \
  --scale-factor 100000 \
  --tables lineitem \
  --parts 1000000000 \
  --part 1 \
  --stdout > /dev/null
```

## Testing

The reproduction command now exits successfully.
