### PR TITLE
fix: align TPC-H scale limits with TPC-DS

### DIFF
--- a/tpcdsgen/src/config/session.rs
+++ b/tpcdsgen/src/config/session.rs
@@ -193,7 +193,7 @@ impl SessionBuilder {
             return Err(InvalidOptionError::with_message(
                 "scale",
                 &self.scale.to_string(),
-                "Scale must be greater than 0 and less than 100000",
+                "Scale must be between 0 and 100000, inclusive",
             )
             .into());
         }

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -126,7 +126,7 @@ struct ParquetArgs {
 
 #[derive(Args)]
 pub struct CommonArgs {
-    /// Scale factor to create
+    /// Scale factor to create (supported range: 0 through 100000, inclusive)
     #[arg(short, long, default_value_t = 1.)]
     scale_factor: f64,
 

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -79,7 +79,7 @@ enum Commands {
 
 #[derive(clap::Args)]
 struct CommonArgs {
-    /// Scale factor to create
+    /// Scale factor to create (supported range: 0 through 100000, inclusive)
     #[arg(short, long, default_value_t = 1.)]
     scale_factor: f64,
 

--- a/tpcgen-cli/src/tpch_cli/plan.rs
+++ b/tpcgen-cli/src/tpch_cli/plan.rs
@@ -62,7 +62,6 @@ pub struct GenerationPlan {
 }
 
 pub const DEFAULT_PARQUET_ROW_GROUP_BYTES: i64 = 7 * 1024 * 1024;
-const MAX_SCALE_FACTOR: f64 = 100_000.0;
 
 impl GenerationPlan {
     /// Returns a GenerationPlan number of parts to generate
@@ -79,9 +78,9 @@ impl GenerationPlan {
         cli_part_count: Option<i32>,
         parquet_row_group_bytes: i64,
     ) -> Result<Self, String> {
-        if !(0.0..=MAX_SCALE_FACTOR).contains(&scale_factor) {
+        if !(0.0..=100_000.0).contains(&scale_factor) {
             return Err(format!(
-                "Invalid scale factor. Expected a number between 0 and {MAX_SCALE_FACTOR}, got {scale_factor}"
+                "Invalid scale factor. Expected a number between 0 and 100000, got {scale_factor}"
             ));
         }
 
@@ -668,11 +667,9 @@ mod tests {
 
         #[test]
         fn unsupported_scale_factor() {
-            Test::new()
-                .with_scale_factor(MAX_SCALE_FACTOR + 1.0)
-                .assert_err(
-                    "Invalid scale factor. Expected a number between 0 and 100000, got 100001",
-                );
+            Test::new().with_scale_factor(100_001.0).assert_err(
+                "Invalid scale factor. Expected a number between 0 and 100000, got 100001",
+            );
         }
     }
 

--- a/tpcgen-cli/src/tpch_cli/plan.rs
+++ b/tpcgen-cli/src/tpch_cli/plan.rs
@@ -80,7 +80,7 @@ impl GenerationPlan {
     ) -> Result<Self, String> {
         if !(0.0..=100_000.0).contains(&scale_factor) {
             return Err(format!(
-                "Invalid scale factor. Expected a number between 0 and 100000, got {scale_factor}"
+                "Invalid scale factor. Expected a number between 0 and 100000, inclusive, got {scale_factor}"
             ));
         }
 
@@ -668,7 +668,7 @@ mod tests {
         #[test]
         fn unsupported_scale_factor() {
             Test::new().with_scale_factor(100_001.0).assert_err(
-                "Invalid scale factor. Expected a number between 0 and 100000, got 100001",
+                "Invalid scale factor. Expected a number between 0 and 100000, inclusive, got 100001",
             );
         }
     }

--- a/tpcgen-cli/src/tpch_cli/plan.rs
+++ b/tpcgen-cli/src/tpch_cli/plan.rs
@@ -62,6 +62,7 @@ pub struct GenerationPlan {
 }
 
 pub const DEFAULT_PARQUET_ROW_GROUP_BYTES: i64 = 7 * 1024 * 1024;
+const MAX_SCALE_FACTOR: f64 = 100_000.0;
 
 impl GenerationPlan {
     /// Returns a GenerationPlan number of parts to generate
@@ -78,6 +79,12 @@ impl GenerationPlan {
         cli_part_count: Option<i32>,
         parquet_row_group_bytes: i64,
     ) -> Result<Self, String> {
+        if !(0.0..=MAX_SCALE_FACTOR).contains(&scale_factor) {
+            return Err(format!(
+                "Invalid scale factor. Expected a number between 0 and {MAX_SCALE_FACTOR}, got {scale_factor}"
+            ));
+        }
+
         // If a single part is specified, split it into chunks to enable parallel generation.
         match (cli_part, cli_part_count) {
             (Some(_part), None) => Err(String::from(
@@ -657,6 +664,15 @@ mod tests {
                 .with_cli_part(1) // part 0 of 0 (invalid)
                 .with_cli_part_count(0)
                 .assert_err("Invalid --part_count. Expected a number greater than zero, got 0");
+        }
+
+        #[test]
+        fn unsupported_scale_factor() {
+            Test::new()
+                .with_scale_factor(MAX_SCALE_FACTOR + 1.0)
+                .assert_err(
+                    "Invalid scale factor. Expected a number between 0 and 100000, got 100001",
+                );
         }
     }
 


### PR DESCRIPTION
## Summary

- Bring TPC-H scale-factor validation into parity with TPC-DS by rejecting values outside `0..=100000` in the TPC-H generation plan, matching the existing [TPC-DS validation](https://github.com/datafusion-contrib/tpcgen-rs/blob/6c51a623a39417a8ab97450905befca69abd0712/tpcdsgen/src/config/session.rs#L192-L199).
- Document the supported range in the TPC-H and TPC-DS CLI help, with inclusive validation messages for both.
- Follow the upper bounds in [TPC-H 3.0.1 §4.1.3.1](https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf#page=80) and [TPC-DS 4.0.0 §3.1](https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-DS_v4.0.0.pdf#page=43).

<img width="825" height="379" alt="Screenshot 2026-08-31 at 8 57 09 AM" src="https://github.com/user-attachments/assets/514bae43-35c3-40d2-9680-3f30c3009f41" />


## Context

Follow-up to [#419](https://github.com/datafusion-contrib/tpcgen-rs/pull/419): its overflow investigation found that TPC-H lacked the scale-factor bound already enforced for TPC-DS.

## Testing

`RUSTFLAGS="-C overflow-checks=yes -C debug-assertions=yes" cargo test --locked -p tpcgen-cli`
