### PR TITLE
Remove deprecated TPC-H CLI flags

### DIFF
--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -4,12 +4,11 @@ use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
 use futures::StreamExt;
 use log::debug;
-use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
+use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk, ArrowRowGroupWriterFactory};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
-use parquet::schema::types::SchemaDescPtr;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
@@ -67,15 +66,22 @@ where
             .unwrap(),
     );
 
+    let root_schema = parquet_schema.root_schema_ptr();
+    let writer = SerializedFileWriter::new(writer, root_schema, writer_properties)?;
+    let row_group_factory = Arc::new(ArrowRowGroupWriterFactory::new(
+        &writer,
+        Arc::clone(&schema),
+    ));
+
     // create a stream that computes the data for each row group
     let mut row_group_stream = futures::stream::iter(iter_iter)
-        .map(async |iter| {
-            let parquet_schema = Arc::clone(&parquet_schema);
-            let writer_properties = Arc::clone(&writer_properties);
+        .enumerate()
+        .map(async |(row_group_index, iter)| {
+            let row_group_factory = Arc::clone(&row_group_factory);
             let schema = Arc::clone(&schema);
             // run on a separate thread
             tokio::task::spawn(async move {
-                encode_row_group(parquet_schema, writer_properties, schema, iter)
+                encode_row_group(row_group_factory, row_group_index, schema, iter)
             })
             .await
             .map_err(|e| io::Error::other(format!("Inner task panicked: {e}")))?
@@ -87,16 +93,12 @@ where
     // A blocking task that writes the row groups to the file
     // done in a blocking task to avoid having a thread waiting on IO
     // Now, read each completed row group and write it to the file
-    let root_schema = parquet_schema.root_schema_ptr();
-    let writer_properties_captured = Arc::clone(&writer_properties);
     let (tx, mut rx): (
         Sender<Vec<ArrowColumnChunk>>,
         Receiver<Vec<ArrowColumnChunk>>,
     ) = tokio::sync::mpsc::channel(num_threads);
     let writer_task = tokio::task::spawn_blocking(move || {
-        // Create parquet writer
-        let mut writer =
-            SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
+        let mut writer = writer;
 
         while let Some(column_chunks) = rx.blocking_recv() {
             // Start row group
@@ -142,8 +144,8 @@ where
 ///
 /// Returns an array of [`ArrowColumnChunk`].
 fn encode_row_group<I>(
-    parquet_schema: SchemaDescPtr,
-    writer_properties: Arc<WriterProperties>,
+    row_group_factory: Arc<ArrowRowGroupWriterFactory>,
+    row_group_index: usize,
     schema: SchemaRef,
     iter: I,
 ) -> Result<Vec<ArrowColumnChunk>, io::Error>
@@ -151,13 +153,9 @@ where
     I: RecordBatchReader,
 {
     // Create writers for each of the leaf columns
-    #[allow(deprecated)]
-    let mut col_writers = parquet::arrow::arrow_writer::get_column_writers(
-        &parquet_schema,
-        &writer_properties,
-        &schema,
-    )
-    .map_err(io::Error::other)?;
+    let mut col_writers = row_group_factory
+        .create_column_writers(row_group_index)
+        .map_err(io::Error::other)?;
 
     // generate the data and send it to the tasks (via the sender channels)
     for batch in iter {

--- a/tpcgen-cli/src/parquet.rs
+++ b/tpcgen-cli/src/parquet.rs
@@ -4,11 +4,12 @@ use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
 use futures::StreamExt;
 use log::debug;
-use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk, ArrowRowGroupWriterFactory};
+use parquet::arrow::arrow_writer::{compute_leaves, ArrowColumnChunk};
 use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::types::SchemaDescPtr;
 use std::io;
 use std::io::Write;
 use std::sync::Arc;
@@ -66,22 +67,15 @@ where
             .unwrap(),
     );
 
-    let root_schema = parquet_schema.root_schema_ptr();
-    let writer = SerializedFileWriter::new(writer, root_schema, writer_properties)?;
-    let row_group_factory = Arc::new(ArrowRowGroupWriterFactory::new(
-        &writer,
-        Arc::clone(&schema),
-    ));
-
     // create a stream that computes the data for each row group
     let mut row_group_stream = futures::stream::iter(iter_iter)
-        .enumerate()
-        .map(async |(row_group_index, iter)| {
-            let row_group_factory = Arc::clone(&row_group_factory);
+        .map(async |iter| {
+            let parquet_schema = Arc::clone(&parquet_schema);
+            let writer_properties = Arc::clone(&writer_properties);
             let schema = Arc::clone(&schema);
             // run on a separate thread
             tokio::task::spawn(async move {
-                encode_row_group(row_group_factory, row_group_index, schema, iter)
+                encode_row_group(parquet_schema, writer_properties, schema, iter)
             })
             .await
             .map_err(|e| io::Error::other(format!("Inner task panicked: {e}")))?
@@ -93,12 +87,16 @@ where
     // A blocking task that writes the row groups to the file
     // done in a blocking task to avoid having a thread waiting on IO
     // Now, read each completed row group and write it to the file
+    let root_schema = parquet_schema.root_schema_ptr();
+    let writer_properties_captured = Arc::clone(&writer_properties);
     let (tx, mut rx): (
         Sender<Vec<ArrowColumnChunk>>,
         Receiver<Vec<ArrowColumnChunk>>,
     ) = tokio::sync::mpsc::channel(num_threads);
     let writer_task = tokio::task::spawn_blocking(move || {
-        let mut writer = writer;
+        // Create parquet writer
+        let mut writer =
+            SerializedFileWriter::new(writer, root_schema, writer_properties_captured).unwrap();
 
         while let Some(column_chunks) = rx.blocking_recv() {
             // Start row group
@@ -144,8 +142,8 @@ where
 ///
 /// Returns an array of [`ArrowColumnChunk`].
 fn encode_row_group<I>(
-    row_group_factory: Arc<ArrowRowGroupWriterFactory>,
-    row_group_index: usize,
+    parquet_schema: SchemaDescPtr,
+    writer_properties: Arc<WriterProperties>,
     schema: SchemaRef,
     iter: I,
 ) -> Result<Vec<ArrowColumnChunk>, io::Error>
@@ -153,9 +151,13 @@ where
     I: RecordBatchReader,
 {
     // Create writers for each of the leaf columns
-    let mut col_writers = row_group_factory
-        .create_column_writers(row_group_index)
-        .map_err(io::Error::other)?;
+    #[allow(deprecated)]
+    let mut col_writers = parquet::arrow::arrow_writer::get_column_writers(
+        &parquet_schema,
+        &writer_properties,
+        &schema,
+    )
+    .map_err(io::Error::other)?;
 
     // generate the data and send it to the tasks (via the sender channels)
     for batch in iter {

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -60,8 +60,6 @@ pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    // Reject top-level arguments when a subcommand is present instead of
-    // silently ignoring them (e.g. `tpchgen-cli -s 10 parquet` is an error).
     #[command(flatten)]
     args: CommonArgs,
 }

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -336,6 +336,7 @@ impl Cli {
         }
     }
 
+    /// Generate TBL output when no output-format subcommand is specified.
     async fn run_default(self) -> io::Result<()> {
         self.args
             .builder(OutputFormat::Tbl)

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -60,9 +60,8 @@ pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    // Top-level args are used for the default TBL output.
-    // args_conflicts_with_subcommands prevents these from being silently ignored
-    // when a subcommand is present (e.g. `tpchgen-cli -s 10 parquet` is an error).
+    // Reject top-level arguments when a subcommand is present instead of
+    // silently ignoring them (e.g. `tpchgen-cli -s 10 parquet` is an error).
     #[command(flatten)]
     args: CommonArgs,
 }

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -60,11 +60,11 @@ pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    // Top-level args are only used when no subcommand is given (legacy path).
+    // Top-level args are used for the default TBL output.
     // args_conflicts_with_subcommands prevents these from being silently ignored
     // when a subcommand is present (e.g. `tpchgen-cli -s 10 parquet` is an error).
     #[command(flatten)]
-    args: TopLevelArgs,
+    args: CommonArgs,
 }
 
 #[derive(clap::Subcommand)]
@@ -196,26 +196,6 @@ impl CommonArgs {
         // interleaved with bar redraws on shared shells.
         self.progress_bars_enabled && !self.quiet && !self.stdout && io::stderr().is_terminal()
     }
-}
-
-#[derive(clap::Args)]
-struct TopLevelArgs {
-    #[command(flatten)]
-    common: CommonArgs,
-
-    /// Output format (deprecated: use subcommands `tbl`, `csv`, or `parquet` instead)
-    ///
-    /// The --format flag will be removed in v4.0.0.
-    #[arg(short, long, hide = true)]
-    format: Option<OutputFormat>,
-
-    /// Parquet block compression format (deprecated: use 'parquet' subcommand instead)
-    #[arg(short = 'c', long, hide = true)]
-    parquet_compression: Option<Compression>,
-
-    /// Target row group size in bytes (deprecated: use 'parquet' subcommand instead)
-    #[arg(long, hide = true)]
-    parquet_row_group_bytes: Option<i64>,
 }
 
 #[derive(clap::Args)]
@@ -360,44 +340,11 @@ impl Cli {
     }
 
     async fn run_default(self) -> io::Result<()> {
-        // Warn about --format migration to subcommands (only when explicitly provided)
-        let (format, subcommand) = if let Some(format) = self.args.format {
-            let subcommand = match format {
-                OutputFormat::Parquet => "parquet",
-                OutputFormat::Csv => "csv",
-                OutputFormat::Tbl => "tbl",
-            };
-            (format, Some(subcommand))
-        } else {
-            (OutputFormat::Tbl, None)
-        };
-
-        let mut builder = self.args.common.builder(format);
-        if let Some(subcommand) = subcommand {
-            log::warn!(
-                "The --format flag will be removed in v4.0.0. Use `tpchgen-cli {subcommand}` instead."
-            );
-        }
-
-        if let Some(parquet_compression) = self.args.parquet_compression {
-            if format == OutputFormat::Parquet {
-                log::warn!("The --parquet-compression flag is deprecated. Use 'tpchgen-cli parquet --compression=...' instead");
-                builder = builder.with_parquet_compression(parquet_compression);
-            } else {
-                log::warn!("--parquet-compression ignored: output format is not parquet");
-            }
-        }
-
-        if let Some(parquet_row_group_bytes) = self.args.parquet_row_group_bytes {
-            if format == OutputFormat::Parquet {
-                log::warn!("The --parquet-row-group-bytes flag is deprecated. Use 'tpchgen-cli parquet --row-group-bytes=...' instead");
-                builder = builder.with_parquet_row_group_bytes(parquet_row_group_bytes);
-            } else {
-                log::warn!("--parquet-row-group-bytes ignored: output format is not parquet");
-            }
-        }
-
-        builder.build().generate().await
+        self.args
+            .builder(OutputFormat::Tbl)
+            .build()
+            .generate()
+            .await
     }
 }
 

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -697,68 +697,6 @@ fn test_tpchgen_cli_rejects_zero_num_threads() {
         ));
 }
 
-/// Test specifying parquet options even when writing tbl output
-#[tokio::test]
-async fn test_incompatible_options_warnings() {
-    let output_dir = tempdir().unwrap();
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("csv")
-        .arg("--tables")
-        .arg("orders")
-        .arg("--scale-factor")
-        .arg("0.0001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        // pass in parquet options that are incompatible with csv
-        .arg("--parquet-compression")
-        .arg("zstd(1)")
-        .arg("--parquet-row-group-bytes")
-        .arg("8192")
-        .assert()
-        // still success, but should see warnings in stderr
-        .success()
-        .stderr(predicates::str::contains(
-            "--parquet-compression ignored: output format is not parquet",
-        ))
-        .stderr(predicates::str::contains(
-            "--parquet-row-group-bytes ignored: output format is not parquet",
-        ));
-}
-
-/// Test that --quiet flag suppresses warning messages
-#[tokio::test]
-async fn test_quiet_flag_suppresses_warnings() {
-    let output_dir = tempdir().unwrap();
-    let output = cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .env("RUST_LOG", "warn")
-        .arg("--format")
-        .arg("csv")
-        .arg("--tables")
-        .arg("orders")
-        .arg("--scale-factor")
-        .arg("0.0001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        // pass in parquet options that are incompatible with csv
-        .arg("--parquet-compression")
-        .arg("zstd(1)")
-        .arg("--parquet-row-group-bytes")
-        .arg("8192")
-        .arg("--quiet")
-        .assert()
-        .success();
-
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
-    assert!(
-        !stderr.contains("Parquet"),
-        "Expected no warning messages in stderr with --quiet flag, but found: {}",
-        stderr
-    );
-}
-
 /// Test that --no-progress is accepted and produces no progress bar output.
 /// Note: in `assert_cmd`-driven tests stderr is not a TTY so progress is also
 /// auto-disabled; this test mainly locks in the flag's existence and verifies
@@ -837,120 +775,22 @@ fn read_reference_file(table_name: &str, scale_factor: &str) -> String {
     }
 }
 
-/// Test that --format=parquet emits a warning about v4.0.0 migration
-#[tokio::test]
-async fn test_format_parquet_warns_about_subcommand() {
-    let output_dir = tempdir().unwrap();
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("parquet")
-        .arg("--tables")
-        .arg("part")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        .assert()
-        .success()
-        .stderr(predicates::str::contains("will be removed in v4.0.0"));
-}
-
-/// Test that using --format together with a subcommand errors
+/// Retired compatibility flags are rejected.
 #[test]
-fn test_format_with_subcommand_conflict() {
-    let temp_dir = tempdir().expect("Failed to create temporary directory");
-
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("parquet")
-        .arg("parquet")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--tables")
-        .arg("part")
-        .arg("--output-dir")
-        .arg(temp_dir.path())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains("cannot be used with"));
-}
-
-/// Test that using --parquet-compression together with a subcommand errors
-#[test]
-fn test_parquet_compression_with_subcommand_conflict() {
-    let temp_dir = tempdir().expect("Failed to create temporary directory");
-
-    // With parquet subcommand
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--parquet-compression")
-        .arg("SNAPPY")
-        .arg("parquet")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--tables")
-        .arg("part")
-        .arg("--output-dir")
-        .arg(temp_dir.path())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains("cannot be used with"));
-
-    // With tbl subcommand
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--parquet-compression")
-        .arg("SNAPPY")
-        .arg("tbl")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--tables")
-        .arg("part")
-        .arg("--output-dir")
-        .arg(temp_dir.path())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains("cannot be used with"));
-}
-
-/// Test that using --parquet-row-group-bytes together with a subcommand errors
-#[test]
-fn test_parquet_row_group_bytes_with_subcommand_conflict() {
-    let temp_dir = tempdir().expect("Failed to create temporary directory");
-
-    // With parquet subcommand
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--parquet-row-group-bytes")
-        .arg("1000000")
-        .arg("parquet")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--tables")
-        .arg("part")
-        .arg("--output-dir")
-        .arg(temp_dir.path())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains("cannot be used with"));
-
-    // With csv subcommand
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--parquet-row-group-bytes")
-        .arg("1000000")
-        .arg("csv")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--tables")
-        .arg("part")
-        .arg("--output-dir")
-        .arg(temp_dir.path())
-        .assert()
-        .failure()
-        .stderr(predicates::str::contains("cannot be used with"));
+fn test_deprecated_flags_are_rejected() {
+    for (flag, value) in [
+        ("--format", "parquet"),
+        ("--parquet-compression", "SNAPPY"),
+        ("--parquet-row-group-bytes", "1000000"),
+    ] {
+        cargo_bin_cmd!("tpcgen-cli")
+            .arg("tpch")
+            .arg(flag)
+            .arg(value)
+            .assert()
+            .failure()
+            .stderr(predicates::str::contains("unexpected argument"));
+    }
 }
 
 /// Test that common args before a subcommand are rejected
@@ -986,7 +826,7 @@ fn test_common_args_with_subcommand_conflict() {
         .success();
 }
 
-/// Test that running with no --format and no subcommand defaults to TBL
+/// Test that running with no subcommand defaults to TBL
 #[test]
 fn test_default_format_is_tbl() {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
@@ -1005,7 +845,7 @@ fn test_default_format_is_tbl() {
     let expected_file = temp_dir.path().join("part.tbl");
     assert!(
         expected_file.exists(),
-        "Expected TBL file {:?} to exist when no --format or subcommand is specified",
+        "Expected TBL file {:?} to exist when no subcommand is specified",
         expected_file
     );
 }
@@ -1058,51 +898,6 @@ fn test_csv_subcommand() {
         "Expected CSV file {:?} to exist with `csv` subcommand",
         expected_file
     );
-}
-
-/// Test that --format=csv emits a deprecation warning
-#[tokio::test]
-async fn test_format_csv_warns_about_subcommand() {
-    let output_dir = tempdir().unwrap();
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("csv")
-        .arg("--tables")
-        .arg("part")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        .assert()
-        .success()
-        .stderr(predicates::str::contains("will be removed in v4.0.0"));
-
-    let expected_file = output_dir.path().join("part.csv");
-    assert!(
-        expected_file.exists(),
-        "Expected CSV file {:?} to exist with deprecated --format=csv path",
-        expected_file
-    );
-}
-
-/// Test that --format=tbl emits a deprecation warning
-#[tokio::test]
-async fn test_format_tbl_warns_about_subcommand() {
-    let output_dir = tempdir().unwrap();
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("tbl")
-        .arg("--tables")
-        .arg("part")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        .assert()
-        .success()
-        .stderr(predicates::str::contains("will be removed in v4.0.0"));
 }
 
 /// Test that the `csv` subcommand with a custom delimiter produces tab-delimited output
@@ -1189,66 +984,4 @@ fn test_tbl_subcommand_rejects_delimiter() {
         .assert()
         .failure()
         .stderr(predicates::str::contains("unexpected argument"));
-}
-
-/// Test that deprecated --format=parquet with --parquet-compression still works
-#[tokio::test]
-async fn test_deprecated_parquet_compression_flag_works() {
-    let output_dir = tempdir().unwrap();
-
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("parquet")
-        .arg("--parquet-compression")
-        .arg("ZSTD(1)")
-        .arg("--tables")
-        .arg("region")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        .assert()
-        .success()
-        .stderr(predicates::str::contains(
-            "--parquet-compression flag is deprecated",
-        ));
-
-    let parquet_file = output_dir.path().join("region.parquet");
-    assert!(
-        parquet_file.exists(),
-        "Expected Parquet file {:?} to exist",
-        parquet_file
-    );
-}
-
-/// Test that deprecated --format=parquet with --parquet-row-group-bytes still works
-#[tokio::test]
-async fn test_deprecated_parquet_row_group_bytes_flag_works() {
-    let output_dir = tempdir().unwrap();
-
-    cargo_bin_cmd!("tpcgen-cli")
-        .arg("tpch")
-        .arg("--format")
-        .arg("parquet")
-        .arg("--parquet-row-group-bytes")
-        .arg("1000000")
-        .arg("--tables")
-        .arg("region")
-        .arg("--scale-factor")
-        .arg("0.001")
-        .arg("--output-dir")
-        .arg(output_dir.path())
-        .assert()
-        .success()
-        .stderr(predicates::str::contains(
-            "--parquet-row-group-bytes flag is deprecated",
-        ));
-
-    let parquet_file = output_dir.path().join("region.parquet");
-    assert!(
-        parquet_file.exists(),
-        "Expected Parquet file {:?} to exist",
-        parquet_file
-    );
 }

--- a/tpchgen-cli/README.md
+++ b/tpchgen-cli/README.md
@@ -92,15 +92,3 @@ is not a terminal, e.g. in CI logs).
   which is why it is not included in the table above.
 
 Times to create TPCH tables in Parquet format using `tpchgen-cli` and `duckdb` for various scale factors.
-
-## Deprecation Notice
-
-`--format`, `--parquet-compression`, and `--parquet-row-group-bytes` are deprecated as of v3.x and will be removed in v4.0.0. Use subcommands instead:
-
-```shell
-# Before
-tpchgen-cli --format=parquet --parquet-compression=ZSTD(1) -s 10
-
-# After
-tpchgen-cli parquet --compression=ZSTD(1) -s 10
-```


### PR DESCRIPTION
Removes the TPC-H flags deprecated in [#173](https://github.com/datafusion-contrib/tpcgen-rs/issues/173).

Output format selection moved from `--format` to dedicated subcommands:

- `--format=parquet` → `tpchgen-cli parquet`
- `--format=csv` → `tpchgen-cli csv`
- `--format=tbl` → `tpchgen-cli tbl` (or omit the subcommand)

Parquet-specific options moved from top-level flags to the `parquet` subcommand:

- `--parquet-compression=ZSTD(1)` → `tpchgen-cli parquet --compression=ZSTD(1)`
- `--parquet-row-group-bytes=1000000` → `tpchgen-cli parquet --row-group-bytes=1000000`

Tested with `cargo test -p tpcgen-cli --all-features` and Clippy.