### PR TITLE
fix: align TPC-H Parquet row-group validation with TPC-DS

### DIFF
--- a/tpcgen-cli/src/args.rs
+++ b/tpcgen-cli/src/args.rs
@@ -1,0 +1,34 @@
+//! Shared command-line argument parsing.
+
+pub(crate) fn parse_row_group_bytes<T>(value: &str) -> Result<T, String>
+where
+    T: TryFrom<i128>,
+    T::Error: std::fmt::Display,
+{
+    // A signed intermediate gives i64 and usize the same non-positive-value error.
+    let bytes = value.parse::<i128>().map_err(|err| err.to_string())?;
+    if bytes <= 0 {
+        return Err("must be greater than zero".to_string());
+    }
+    T::try_from(bytes).map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_group_bytes_preserves_integer_ranges() {
+        assert_eq!(
+            parse_row_group_bytes::<i64>(&i64::MAX.to_string()),
+            Ok(i64::MAX)
+        );
+        assert_eq!(
+            parse_row_group_bytes::<usize>(&usize::MAX.to_string()),
+            Ok(usize::MAX)
+        );
+        assert!(parse_row_group_bytes::<i64>("9223372036854775808").is_err());
+        let usize_overflow = (usize::MAX as u128 + 1).to_string();
+        assert!(parse_row_group_bytes::<usize>(&usize_overflow).is_err());
+    }
+}

--- a/tpcgen-cli/src/args.rs
+++ b/tpcgen-cli/src/args.rs
@@ -14,6 +14,7 @@ mod tests {
 
     #[test]
     fn row_group_bytes_enforces_i64_range() {
+        assert_eq!(parse_row_group_bytes("1"), Ok(1));
         assert_eq!(parse_row_group_bytes(&i64::MAX.to_string()), Ok(i64::MAX));
         assert!(parse_row_group_bytes("9223372036854775808").is_err());
     }

--- a/tpcgen-cli/src/args.rs
+++ b/tpcgen-cli/src/args.rs
@@ -1,16 +1,11 @@
 //! Shared command-line argument parsing.
 
-pub(crate) fn parse_row_group_bytes<T>(value: &str) -> Result<T, String>
-where
-    T: TryFrom<i128>,
-    T::Error: std::fmt::Display,
-{
-    // A signed intermediate gives i64 and usize the same non-positive-value error.
-    let bytes = value.parse::<i128>().map_err(|err| err.to_string())?;
+pub(crate) fn parse_row_group_bytes(value: &str) -> Result<i64, String> {
+    let bytes = value.parse::<i64>().map_err(|err| err.to_string())?;
     if bytes <= 0 {
         return Err("must be greater than zero".to_string());
     }
-    T::try_from(bytes).map_err(|err| err.to_string())
+    Ok(bytes)
 }
 
 #[cfg(test)]
@@ -18,17 +13,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn row_group_bytes_preserves_integer_ranges() {
-        assert_eq!(
-            parse_row_group_bytes::<i64>(&i64::MAX.to_string()),
-            Ok(i64::MAX)
-        );
-        assert_eq!(
-            parse_row_group_bytes::<usize>(&usize::MAX.to_string()),
-            Ok(usize::MAX)
-        );
-        assert!(parse_row_group_bytes::<i64>("9223372036854775808").is_err());
-        let usize_overflow = (usize::MAX as u128 + 1).to_string();
-        assert!(parse_row_group_bytes::<usize>(&usize_overflow).is_err());
+    fn row_group_bytes_enforces_i64_range() {
+        assert_eq!(parse_row_group_bytes(&i64::MAX.to_string()), Ok(i64::MAX));
+        assert!(parse_row_group_bytes("9223372036854775808").is_err());
     }
 }

--- a/tpcgen-cli/src/lib.rs
+++ b/tpcgen-cli/src/lib.rs
@@ -1,4 +1,5 @@
 //! This library contains both the TPCH and TPCDS command line clients.
+mod args;
 mod logging;
 mod parquet;
 pub mod progress;

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -25,8 +25,6 @@ mod progress;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-const DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES: usize = DEFAULT_PARQUET_ROW_GROUP_BYTES as usize;
-
 enum OutputFormat {
     Dat(dat::Dat),
     Csv(csv::Csv),
@@ -110,10 +108,10 @@ struct ParquetArgs {
     /// Typical values range from 10MB to 100MB.
     #[arg(
         long,
-        default_value_t = DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
-        value_parser = parse_row_group_bytes::<usize>
+        default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES,
+        value_parser = parse_row_group_bytes
     )]
-    row_group_bytes: usize,
+    row_group_bytes: i64,
 
     /// The number of threads for parallel generation, defaults to the number of CPUs
     #[arg(
@@ -203,7 +201,7 @@ impl CommonArgs {
     async fn run_parquet(
         self,
         compression: Compression,
-        row_group_bytes: usize,
+        row_group_bytes: i64,
         num_threads: usize,
     ) -> Result<()> {
         let output = parquet::Parquet::new(

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -95,7 +95,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target Parquet row-group size in bytes (must be positive)
+    /// Target row-group size in bytes (must be positive)
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -95,7 +95,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target size in row group bytes in Parquet files
+    /// Target Parquet row-group size in bytes (must be positive)
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -1,4 +1,5 @@
 //! TPC-DS data generation CLI with a dbgen compatible API.
+use crate::args::parse_row_group_bytes;
 use crate::logging::configure_logging;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
@@ -110,7 +111,7 @@ struct ParquetArgs {
     #[arg(
         long,
         default_value_t = DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
-        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
+        value_parser = parse_row_group_bytes::<usize>
     )]
     row_group_bytes: usize,
 

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -95,7 +95,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target row-group size in bytes (must be positive)
+    /// Target row-group size in bytes
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better

--- a/tpcgen-cli/src/tpcds_cli.rs
+++ b/tpcgen-cli/src/tpcds_cli.rs
@@ -110,7 +110,7 @@ struct ParquetArgs {
     #[arg(
         long,
         default_value_t = DEFAULT_TPCDS_PARQUET_ROW_GROUP_BYTES,
-        value_parser = parse_row_group_bytes
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..)
     )]
     row_group_bytes: usize,
 
@@ -462,15 +462,6 @@ fn parse_delimiter(s: &str) -> std::result::Result<char, String> {
         ));
     }
     Ok(parsed)
-}
-
-fn parse_row_group_bytes(s: &str) -> std::result::Result<usize, String> {
-    let parsed = s.parse::<usize>().map_err(|e| e.to_string())?;
-    if parsed == 0 {
-        Err("must be greater than zero".to_string())
-    } else {
-        Ok(parsed)
-    }
 }
 
 #[cfg(test)]

--- a/tpcgen-cli/src/tpcds_cli/parquet.rs
+++ b/tpcgen-cli/src/tpcds_cli/parquet.rs
@@ -25,7 +25,7 @@ use tpcdsgen_arrow::{
 pub(super) struct Parquet {
     output_dir: PathBuf,
     compression: Compression,
-    row_group_bytes: usize,
+    row_group_bytes: i64,
     num_threads: usize,
 }
 
@@ -33,7 +33,7 @@ impl Parquet {
     pub(super) fn new(
         output_dir: PathBuf,
         compression: Compression,
-        row_group_bytes: usize,
+        row_group_bytes: i64,
         num_threads: usize,
     ) -> Self {
         Self {

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -27,10 +27,10 @@ pub(super) struct TpcdsGenerationPlan {
 impl TpcdsGenerationPlan {
     /// Compute the row group layout for `table` given the target
     /// `row_group_bytes`.
-    pub(super) fn new(table: Table, scaling: &Scaling, row_group_bytes: usize) -> Self {
+    pub(super) fn new(table: Table, scaling: &Scaling, row_group_bytes: i64) -> Self {
         let source_rows = scaling.get_row_count(table.source_table());
         let estimated_bytes = source_rows.saturating_mul(estimated_bytes_per_source_row(table));
-        let num_row_groups = (estimated_bytes / row_group_bytes.max(1) as i64 + 1)
+        let num_row_groups = (estimated_bytes / row_group_bytes.max(1) + 1)
             .min(MAX_ROW_GROUPS)
             .min(source_rows)
             .max(1);
@@ -169,9 +169,9 @@ fn estimated_bytes_per_source_row(table: Table) -> i64 {
 mod tests {
     use super::*;
 
-    const DEFAULT_ROW_GROUP_BYTES: usize = 7 * 1024 * 1024;
+    const DEFAULT_ROW_GROUP_BYTES: i64 = 7 * 1024 * 1024;
 
-    fn plan(table: Table, scale_factor: f64, row_group_bytes: usize) -> TpcdsGenerationPlan {
+    fn plan(table: Table, scale_factor: f64, row_group_bytes: i64) -> TpcdsGenerationPlan {
         TpcdsGenerationPlan::new(table, &Scaling::new(scale_factor), row_group_bytes)
     }
 
@@ -190,6 +190,12 @@ mod tests {
     fn small_table_single_row_group() {
         let plan = plan(Table::Reason, 1.0, DEFAULT_ROW_GROUP_BYTES);
         assert_eq!(plan.ranges, vec![1..=35]);
+    }
+
+    #[test]
+    fn maximum_row_group_size_uses_single_group() {
+        let plan = plan(Table::StoreSales, 1.0, i64::MAX);
+        assert_eq!(plan.ranges, vec![1..=240_000]);
     }
 
     #[test]

--- a/tpcgen-cli/src/tpcds_cli/plan.rs
+++ b/tpcgen-cli/src/tpcds_cli/plan.rs
@@ -193,12 +193,6 @@ mod tests {
     }
 
     #[test]
-    fn maximum_row_group_size_uses_single_group() {
-        let plan = plan(Table::StoreSales, 1.0, i64::MAX);
-        assert_eq!(plan.ranges, vec![1..=240_000]);
-    }
-
-    #[test]
     fn store_sales_sf1_default() {
         let plan = plan(Table::StoreSales, 1.0, DEFAULT_ROW_GROUP_BYTES);
         // ~568 MB estimated output in 7 MB row groups over 240k source rows

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -237,7 +237,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target Parquet row-group size in bytes (must be positive)
+    /// Target row-group size in bytes (must be positive)
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -237,7 +237,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target size in row group bytes in Parquet files
+    /// Target Parquet row-group size in bytes (must be positive)
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better
@@ -249,7 +249,11 @@ struct ParquetArgs {
     /// groups under this limit.
     ///
     /// Typical values range from 10MB to 100MB.
-    #[arg(long, default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES)]
+    #[arg(
+        long,
+        default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES,
+        value_parser = clap::value_parser!(i64).range(1..)
+    )]
     row_group_bytes: i64,
 }
 
@@ -382,6 +386,16 @@ impl ParquetArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parquet_row_group_bytes_accepts_one() {
+        let cli = Cli::try_parse_from(["tpchgen", "parquet", "--row-group-bytes=1"]).unwrap();
+        let Some(Commands::Parquet(args)) = cli.command else {
+            panic!("expected parquet command")
+        };
+
+        assert_eq!(args.row_group_bytes, 1);
+    }
 
     fn args_with_tables(tables: Vec<Table>) -> CommonArgs {
         CommonArgs {

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -388,16 +388,6 @@ impl ParquetArgs {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parquet_row_group_bytes_accepts_one() {
-        let cli = Cli::try_parse_from(["tpchgen", "parquet", "--row-group-bytes=1"]).unwrap();
-        let Some(Commands::Parquet(args)) = cli.command else {
-            panic!("expected parquet command")
-        };
-
-        assert_eq!(args.row_group_bytes, 1);
-    }
-
     fn args_with_tables(tables: Vec<Table>) -> CommonArgs {
         CommonArgs {
             scale_factor: 1.0,

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -237,7 +237,7 @@ struct ParquetArgs {
     #[arg(short = 'c', long, default_value = "SNAPPY")]
     compression: Compression,
 
-    /// Target row-group size in bytes (must be positive)
+    /// Target row-group size in bytes
     ///
     /// Row groups are the typical unit of parallel processing and compression
     /// with many query engines. Therefore, smaller row groups enable better

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -253,7 +253,7 @@ struct ParquetArgs {
     #[arg(
         long,
         default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES,
-        value_parser = parse_row_group_bytes::<i64>
+        value_parser = parse_row_group_bytes
     )]
     row_group_bytes: i64,
 }

--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -2,6 +2,7 @@ use super::{
     Compression, OutputFormat, Table, TpchGenerator, TpchGeneratorBuilder,
     DEFAULT_PARQUET_ROW_GROUP_BYTES,
 };
+use crate::args::parse_row_group_bytes;
 use crate::logging::configure_logging;
 #[cfg(feature = "indicatif-progress")]
 use crate::progress::IndicatifProgress;
@@ -252,7 +253,7 @@ struct ParquetArgs {
     #[arg(
         long,
         default_value_t = DEFAULT_PARQUET_ROW_GROUP_BYTES,
-        value_parser = clap::value_parser!(i64).range(1..)
+        value_parser = parse_row_group_bytes::<i64>
     )]
     row_group_bytes: i64,
 }

--- a/tpcgen-cli/tests/cli_integration.rs
+++ b/tpcgen-cli/tests/cli_integration.rs
@@ -45,10 +45,9 @@ fn test_parquet_rejects_non_positive_row_group_bytes() {
                 .assert()
                 .code(2)
                 .stdout("")
-                .stderr(predicates::str::contains("error: invalid value"))
-                .stderr(predicates::str::contains(
-                    "--row-group-bytes <ROW_GROUP_BYTES>",
-                ));
+                .stderr(predicates::str::contains(format!(
+                    "error: invalid value '{value}' for '--row-group-bytes <ROW_GROUP_BYTES>': must be greater than zero"
+                )));
 
             assert!(
                 !output_dir.exists(),

--- a/tpcgen-cli/tests/cli_integration.rs
+++ b/tpcgen-cli/tests/cli_integration.rs
@@ -22,3 +22,36 @@ fn test_tpcgen_cli_requires_command() {
         .stderr(predicates::str::contains("tpch"))
         .stderr(predicates::str::contains("tpcds"));
 }
+
+#[test]
+fn test_parquet_rejects_non_positive_row_group_bytes() {
+    for (benchmark, table) in [("tpch", "region"), ("tpcds", "reason")] {
+        for value in ["0", "-1"] {
+            let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+            let output_dir = temp_dir.path().join("output");
+
+            cargo_bin_cmd!("tpcgen-cli")
+                .args([
+                    benchmark,
+                    "parquet",
+                    "--scale-factor",
+                    "0.001",
+                    "--tables",
+                    table,
+                ])
+                .arg("--output-dir")
+                .arg(&output_dir)
+                .arg(format!("--row-group-bytes={value}"))
+                .assert()
+                .code(2)
+                .stdout("")
+                .stderr(predicates::str::contains("error: invalid value"))
+                .stderr(predicates::str::contains("--row-group-bytes <ROW_GROUP_BYTES>"));
+
+            assert!(
+                !output_dir.exists(),
+                "Invalid row-group size must not create output: {benchmark} {value}"
+            );
+        }
+    }
+}

--- a/tpcgen-cli/tests/cli_integration.rs
+++ b/tpcgen-cli/tests/cli_integration.rs
@@ -46,7 +46,9 @@ fn test_parquet_rejects_non_positive_row_group_bytes() {
                 .code(2)
                 .stdout("")
                 .stderr(predicates::str::contains("error: invalid value"))
-                .stderr(predicates::str::contains("--row-group-bytes <ROW_GROUP_BYTES>"));
+                .stderr(predicates::str::contains(
+                    "--row-group-bytes <ROW_GROUP_BYTES>",
+                ));
 
             assert!(
                 !output_dir.exists(),

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -289,9 +289,9 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_zero_row_group_bytes() {
         .code(2);
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-    assert!(
-        stderr.contains("error: invalid value '0' for '--row-group-bytes <ROW_GROUP_BYTES>'"),
-        "Expected --row-group-bytes=0 to be rejected at argument parse time, got stderr: {stderr}"
+    assert_eq!(
+        stderr,
+        "error: invalid value '0' for '--row-group-bytes <ROW_GROUP_BYTES>': must be greater than zero\n\nFor more information, try '--help'.\n"
     );
 }
 

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -286,12 +286,12 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_zero_row_group_bytes() {
         .arg("--row-group-bytes")
         .arg("0")
         .assert()
-        .failure();
+        .code(2);
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-    assert_eq!(
-        stderr,
-        "error: invalid value '0' for '--row-group-bytes <ROW_GROUP_BYTES>': must be greater than zero\n\nFor more information, try '--help'.\n"
+    assert!(
+        stderr.contains("error: invalid value '0' for '--row-group-bytes <ROW_GROUP_BYTES>'"),
+        "Expected --row-group-bytes=0 to be rejected at argument parse time, got stderr: {stderr}"
     );
 }
 

--- a/tpcgen-cli/tests/cli_integration/tpcds.rs
+++ b/tpcgen-cli/tests/cli_integration/tpcds.rs
@@ -286,7 +286,7 @@ fn test_tpcgen_cli_tpcds_parquet_rejects_zero_row_group_bytes() {
         .arg("--row-group-bytes")
         .arg("0")
         .assert()
-        .code(2);
+        .failure();
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert_eq!(


### PR DESCRIPTION
Aligns TPC-H with the TPC-DS argument validation added in #349, addressing the row-group size checklist item in #423.

TPC-H previously panicked on zero and could produce an invalid empty file for negative `--row-group-bytes` values. Both CLIs now share an `i64` parser that rejects non-positive values before generation with `must be greater than zero`.

TPC-DS also uses `i64` throughout row-group planning, removing its unchecked `usize`-to-`i64` cast. Both commands now accept positive values up to `i64::MAX`; defaults are unchanged. The TPC-H fix also covers standalone `tpchgen-cli parquet`.

Both benchmarks use concise option descriptions (help excerpts):

```text
$ tpcgen-cli tpch parquet --help
      --row-group-bytes <ROW_GROUP_BYTES>
          Target row-group size in bytes

$ tpcgen-cli tpcds parquet --help
      --row-group-bytes <ROW_GROUP_BYTES>
          Target row-group size in bytes
```