### PR TITLE
Align TPC-H invalid-table errors with TPC-DS

### DIFF
--- a/tpcgen-cli/src/tpch_cli/cli.rs
+++ b/tpcgen-cli/src/tpch_cli/cli.rs
@@ -299,11 +299,25 @@ impl TypedValueParser for TableValueParser {
         _: Option<&clap::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, clap::Error> {
+        let to_err = |msg: String| {
+            clap::Error::raw(clap::error::ErrorKind::InvalidValue, format!("{msg}\n")).with_cmd(cmd)
+        };
+
         let value = value
             .to_str()
-            .ok_or_else(|| clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd))?;
-        Table::from_str(value)
-            .map_err(|_| clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd))
+            .ok_or_else(|| to_err("table names must be valid UTF-8".to_string()))?;
+
+        Table::from_str(value).map_err(|_| {
+            let expected = self
+                .possible_values()
+                .expect("table parser defines possible values")
+                .map(|table| table.get_name().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            to_err(format!(
+                "unknown table '{value}'. Expected one of: {expected}"
+            ))
+        })
     }
 
     fn possible_values(

--- a/tpcgen-cli/tests/cli_integration.rs
+++ b/tpcgen-cli/tests/cli_integration.rs
@@ -11,27 +11,6 @@ mod tpch;
 #[path = "cli_integration/tpcds.rs"]
 mod tpcds;
 
-#[cfg(unix)]
-#[test]
-fn test_tpcgen_cli_rejects_non_utf8_table_names() {
-    use std::ffi::OsStr;
-    use std::os::unix::ffi::OsStrExt;
-
-    for benchmark in ["tpch", "tpcds"] {
-        let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
-        cargo_bin_cmd!("tpcgen-cli")
-            .args([benchmark, "--tables"])
-            .arg(OsStr::from_bytes(b"\xff"))
-            .arg("--output-dir")
-            .arg(temp_dir.path())
-            .assert()
-            .code(2)
-            .stderr(predicates::str::contains(
-                "error: table names must be valid UTF-8\n",
-            ));
-    }
-}
-
 /// Test that invoking the CLI without a command reports the top-level usage.
 #[test]
 fn test_tpcgen_cli_requires_command() {

--- a/tpcgen-cli/tests/cli_integration.rs
+++ b/tpcgen-cli/tests/cli_integration.rs
@@ -11,6 +11,27 @@ mod tpch;
 #[path = "cli_integration/tpcds.rs"]
 mod tpcds;
 
+#[cfg(unix)]
+#[test]
+fn test_tpcgen_cli_rejects_non_utf8_table_names() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+
+    for benchmark in ["tpch", "tpcds"] {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temporary directory");
+        cargo_bin_cmd!("tpcgen-cli")
+            .args([benchmark, "--tables"])
+            .arg(OsStr::from_bytes(b"\xff"))
+            .arg("--output-dir")
+            .arg(temp_dir.path())
+            .assert()
+            .code(2)
+            .stderr(predicates::str::contains(
+                "error: table names must be valid UTF-8\n",
+            ));
+    }
+}
+
 /// Test that invoking the CLI without a command reports the top-level usage.
 #[test]
 fn test_tpcgen_cli_requires_command() {

--- a/tpcgen-cli/tests/cli_integration/tpch.rs
+++ b/tpcgen-cli/tests/cli_integration/tpch.rs
@@ -10,6 +10,21 @@ use tempfile::tempdir;
 use tpchgen::generators::OrderGenerator;
 use tpchgen_arrow::OrderArrow;
 
+#[test]
+fn test_tpcgen_cli_tpch_unknown_table_error_lists_valid_tables() {
+    let temp_dir = tempdir().expect("Failed to create temporary directory");
+
+    cargo_bin_cmd!("tpcgen-cli")
+        .args(["tpch", "parquet", "--tables", "region,store_sales"])
+        .arg("--output-dir")
+        .arg(temp_dir.path())
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains(
+            "unknown table 'store_sales'. Expected one of: region, nation, supplier, customer, part, partsupp, orders, lineitem\n",
+        ));
+}
+
 /// Test the TPC-H command forms for the `tpcgen-cli` binary.
 #[test]
 fn test_tpcgen_cli_tpch_command_forms() {


### PR DESCRIPTION
Bring TPC-H table argument errors into parity with TPC-DS: identify unknown values, list valid tables for the selected benchmark, and report non-UTF-8 input consistently.

Part of #423.