### PR TITLE
Align TPC-H table-name casing with TPC-DS

### DIFF
--- a/tpcgen-cli/bin/tpcgen_cli.rs
+++ b/tpcgen-cli/bin/tpcgen_cli.rs
@@ -64,3 +64,62 @@ async fn main() -> ExitCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+    use tpcgen_cli::tpch_cli::Table;
+
+    #[test]
+    fn full_table_names_are_case_insensitive() {
+        for (benchmark, name) in [
+            ("tpch", "Nation"),
+            ("tpch", "Region"),
+            ("tpch", "Supplier"),
+            ("tpch", "Part"),
+            ("tpch", "PartSupp"),
+            ("tpch", "Customer"),
+            ("tpch", "Orders"),
+            ("tpch", "LineItem"),
+            ("tpcds", "Reason"),
+            ("tpcds", "Ship_Mode"),
+        ] {
+            for name in [
+                name.to_ascii_lowercase(),
+                name.to_ascii_uppercase(),
+                name.to_string(),
+            ] {
+                Cli::try_parse_from(["tpcgen-cli", benchmark, "--tables", &name]).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn tpch_table_aliases_remain_case_sensitive() {
+        // Only TPC-H: the Rust TPC-DS CLI does not support table aliases.
+        for (alias, table) in [
+            ("n", Table::Nation),
+            ("r", Table::Region),
+            ("s", Table::Supplier),
+            ("P", Table::Part),
+            ("S", Table::Partsupp),
+            ("c", Table::Customer),
+            ("O", Table::Orders),
+            ("L", Table::Lineitem),
+        ] {
+            let matches = Cli::command()
+                .try_get_matches_from(["tpcgen-cli", "tpch", "--tables", alias])
+                .unwrap();
+            let tpch = matches.subcommand_matches("tpch").unwrap();
+            assert_eq!(tpch.get_one::<Table>("tables"), Some(&table), "{alias}");
+        }
+
+        for alias in ["N", "R", "p", "C", "o", "l"] {
+            assert!(
+                Cli::try_parse_from(["tpcgen-cli", "tpch", "--tables", alias]).is_err(),
+                "{alias}"
+            );
+        }
+    }
+}

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -99,27 +99,22 @@ impl FromStr for Table {
     /// not support this since it just adds unnecessary complexity and confusion so we
     /// only support the exclusive abbreviations.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "n" => Ok(Table::Nation),
-            "r" => Ok(Table::Region),
-            "s" => Ok(Table::Supplier),
-            "P" => Ok(Table::Part),
-            "S" => Ok(Table::Partsupp),
-            "c" => Ok(Table::Customer),
-            "O" => Ok(Table::Orders),
-            "L" => Ok(Table::Lineitem),
-            _ => match s.to_ascii_lowercase().as_str() {
-                "nation" => Ok(Table::Nation),
-                "region" => Ok(Table::Region),
-                "supplier" => Ok(Table::Supplier),
-                "part" => Ok(Table::Part),
-                "partsupp" => Ok(Table::Partsupp),
-                "customer" => Ok(Table::Customer),
-                "orders" => Ok(Table::Orders),
-                "lineitem" => Ok(Table::Lineitem),
-                _ => Err("Invalid table name {s}"),
-            },
+        for (alias, table) in [
+            ("n", Table::Nation),
+            ("r", Table::Region),
+            ("s", Table::Supplier),
+            ("P", Table::Part),
+            ("S", Table::Partsupp),
+            ("c", Table::Customer),
+            ("O", Table::Orders),
+            ("L", Table::Lineitem),
+        ] {
+            if s == alias || s.eq_ignore_ascii_case(table.name()) {
+                return Ok(table);
+            }
         }
+
+        Err("Invalid table name {s}")
     }
 }
 

--- a/tpcgen-cli/src/tpch_cli/generator.rs
+++ b/tpcgen-cli/src/tpch_cli/generator.rs
@@ -100,15 +100,25 @@ impl FromStr for Table {
     /// only support the exclusive abbreviations.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "n" | "nation" => Ok(Table::Nation),
-            "r" | "region" => Ok(Table::Region),
-            "s" | "supplier" => Ok(Table::Supplier),
-            "P" | "part" => Ok(Table::Part),
-            "S" | "partsupp" => Ok(Table::Partsupp),
-            "c" | "customer" => Ok(Table::Customer),
-            "O" | "orders" => Ok(Table::Orders),
-            "L" | "lineitem" => Ok(Table::Lineitem),
-            _ => Err("Invalid table name {s}"),
+            "n" => Ok(Table::Nation),
+            "r" => Ok(Table::Region),
+            "s" => Ok(Table::Supplier),
+            "P" => Ok(Table::Part),
+            "S" => Ok(Table::Partsupp),
+            "c" => Ok(Table::Customer),
+            "O" => Ok(Table::Orders),
+            "L" => Ok(Table::Lineitem),
+            _ => match s.to_ascii_lowercase().as_str() {
+                "nation" => Ok(Table::Nation),
+                "region" => Ok(Table::Region),
+                "supplier" => Ok(Table::Supplier),
+                "part" => Ok(Table::Part),
+                "partsupp" => Ok(Table::Partsupp),
+                "customer" => Ok(Table::Customer),
+                "orders" => Ok(Table::Orders),
+                "lineitem" => Ok(Table::Lineitem),
+                _ => Err("Invalid table name {s}"),
+            },
         }
     }
 }


### PR DESCRIPTION
The TPC-DS CLI already accepts full table names case-insensitively, but the TPC-H CLI is case-sensitive. This PR makes TPC-H full table names case-insensitive too, so `--tables REGION`, `--tables Region`, and `--tables region` all work.

TPC-H short aliases remain case-sensitive: `s` selects supplier, while `S` selects partsupp. The TPC-DS CLI does not support short aliases.

Part of #423.