### PR TITLE
Expose Arrow schemas without constructing generators

### DIFF
--- a/tpcdsgen-arrow/src/tables/call_center.rs
+++ b/tpcdsgen-arrow/src/tables/call_center.rs
@@ -17,6 +17,11 @@ pub struct CallCenterArrow {
 }
 
 impl CallCenterArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::CallCenter);
         Self {
@@ -50,7 +55,7 @@ impl CallCenterArrow {
 
 impl RecordBatchReader for CallCenterArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/catalog_page.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_page.rs
@@ -14,6 +14,11 @@ pub struct CatalogPageArrow {
 }
 
 impl CatalogPageArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::CatalogPage);
         Self {
@@ -47,7 +52,7 @@ impl CatalogPageArrow {
 
 impl RecordBatchReader for CatalogPageArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/catalog_returns.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_returns.rs
@@ -14,6 +14,11 @@ pub struct CatalogReturnsArrow {
 }
 
 impl CatalogReturnsArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::CatalogSales);
         Self {
@@ -47,7 +52,7 @@ impl CatalogReturnsArrow {
 
 impl RecordBatchReader for CatalogReturnsArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/catalog_sales.rs
+++ b/tpcdsgen-arrow/src/tables/catalog_sales.rs
@@ -14,6 +14,11 @@ pub struct CatalogSalesArrow {
 }
 
 impl CatalogSalesArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::CatalogSales);
         Self {
@@ -47,7 +52,7 @@ impl CatalogSalesArrow {
 
 impl RecordBatchReader for CatalogSalesArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/customer.rs
+++ b/tpcdsgen-arrow/src/tables/customer.rs
@@ -14,6 +14,11 @@ pub struct CustomerArrow {
 }
 
 impl CustomerArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Customer);
         Self {
@@ -47,7 +52,7 @@ impl CustomerArrow {
 
 impl RecordBatchReader for CustomerArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/customer_address.rs
+++ b/tpcdsgen-arrow/src/tables/customer_address.rs
@@ -14,6 +14,11 @@ pub struct CustomerAddressArrow {
 }
 
 impl CustomerAddressArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::CustomerAddress);
         Self {
@@ -47,7 +52,7 @@ impl CustomerAddressArrow {
 
 impl RecordBatchReader for CustomerAddressArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/customer_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/customer_demographics.rs
@@ -14,6 +14,11 @@ pub struct CustomerDemographicsArrow {
 }
 
 impl CustomerDemographicsArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session
             .get_scaling()
@@ -49,7 +54,7 @@ impl CustomerDemographicsArrow {
 
 impl RecordBatchReader for CustomerDemographicsArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/date_dim.rs
+++ b/tpcdsgen-arrow/src/tables/date_dim.rs
@@ -14,6 +14,11 @@ pub struct DateDimArrow {
 }
 
 impl DateDimArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::DateDim);
         Self {
@@ -47,7 +52,7 @@ impl DateDimArrow {
 
 impl RecordBatchReader for DateDimArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/dbgen_version.rs
+++ b/tpcdsgen-arrow/src/tables/dbgen_version.rs
@@ -14,6 +14,11 @@ pub struct DbgenVersionArrow {
 }
 
 impl DbgenVersionArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::DbgenVersion);
         Self {
@@ -47,7 +52,7 @@ impl DbgenVersionArrow {
 
 impl RecordBatchReader for DbgenVersionArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/household_demographics.rs
+++ b/tpcdsgen-arrow/src/tables/household_demographics.rs
@@ -14,6 +14,11 @@ pub struct HouseholdDemographicsArrow {
 }
 
 impl HouseholdDemographicsArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session
             .get_scaling()
@@ -49,7 +54,7 @@ impl HouseholdDemographicsArrow {
 
 impl RecordBatchReader for HouseholdDemographicsArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/income_band.rs
+++ b/tpcdsgen-arrow/src/tables/income_band.rs
@@ -14,6 +14,11 @@ pub struct IncomeBandArrow {
 }
 
 impl IncomeBandArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::IncomeBand);
         Self {
@@ -47,7 +52,7 @@ impl IncomeBandArrow {
 
 impl RecordBatchReader for IncomeBandArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/inventory.rs
+++ b/tpcdsgen-arrow/src/tables/inventory.rs
@@ -14,6 +14,11 @@ pub struct InventoryArrow {
 }
 
 impl InventoryArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Inventory);
         Self {
@@ -47,7 +52,7 @@ impl InventoryArrow {
 
 impl RecordBatchReader for InventoryArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/item.rs
+++ b/tpcdsgen-arrow/src/tables/item.rs
@@ -16,6 +16,11 @@ pub struct ItemArrow {
 }
 
 impl ItemArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Item);
         Self {
@@ -49,7 +54,7 @@ impl ItemArrow {
 
 impl RecordBatchReader for ItemArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/promotion.rs
+++ b/tpcdsgen-arrow/src/tables/promotion.rs
@@ -16,6 +16,11 @@ pub struct PromotionArrow {
 }
 
 impl PromotionArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Promotion);
         Self {
@@ -49,7 +54,7 @@ impl PromotionArrow {
 
 impl RecordBatchReader for PromotionArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/reason.rs
+++ b/tpcdsgen-arrow/src/tables/reason.rs
@@ -14,6 +14,11 @@ pub struct ReasonArrow {
 }
 
 impl ReasonArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Reason);
         Self {
@@ -47,7 +52,7 @@ impl ReasonArrow {
 
 impl RecordBatchReader for ReasonArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/ship_mode.rs
+++ b/tpcdsgen-arrow/src/tables/ship_mode.rs
@@ -14,6 +14,11 @@ pub struct ShipModeArrow {
 }
 
 impl ShipModeArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::ShipMode);
         Self {
@@ -47,7 +52,7 @@ impl ShipModeArrow {
 
 impl RecordBatchReader for ShipModeArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/store.rs
+++ b/tpcdsgen-arrow/src/tables/store.rs
@@ -17,6 +17,11 @@ pub struct StoreArrow {
 }
 
 impl StoreArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Store);
         Self {
@@ -50,7 +55,7 @@ impl StoreArrow {
 
 impl RecordBatchReader for StoreArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/store_returns.rs
+++ b/tpcdsgen-arrow/src/tables/store_returns.rs
@@ -14,6 +14,11 @@ pub struct StoreReturnsArrow {
 }
 
 impl StoreReturnsArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::StoreSales);
         Self {
@@ -47,7 +52,7 @@ impl StoreReturnsArrow {
 
 impl RecordBatchReader for StoreReturnsArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/store_sales.rs
+++ b/tpcdsgen-arrow/src/tables/store_sales.rs
@@ -14,6 +14,11 @@ pub struct StoreSalesArrow {
 }
 
 impl StoreSalesArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::StoreSales);
         Self {
@@ -47,7 +52,7 @@ impl StoreSalesArrow {
 
 impl RecordBatchReader for StoreSalesArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/time_dim.rs
+++ b/tpcdsgen-arrow/src/tables/time_dim.rs
@@ -14,6 +14,11 @@ pub struct TimeDimArrow {
 }
 
 impl TimeDimArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::TimeDim);
         Self {
@@ -47,7 +52,7 @@ impl TimeDimArrow {
 
 impl RecordBatchReader for TimeDimArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/warehouse.rs
+++ b/tpcdsgen-arrow/src/tables/warehouse.rs
@@ -14,6 +14,11 @@ pub struct WarehouseArrow {
 }
 
 impl WarehouseArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::Warehouse);
         Self {
@@ -47,7 +52,7 @@ impl WarehouseArrow {
 
 impl RecordBatchReader for WarehouseArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/web_page.rs
+++ b/tpcdsgen-arrow/src/tables/web_page.rs
@@ -16,6 +16,11 @@ pub struct WebPageArrow {
 }
 
 impl WebPageArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::WebPage);
         Self {
@@ -49,7 +54,7 @@ impl WebPageArrow {
 
 impl RecordBatchReader for WebPageArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/web_returns.rs
+++ b/tpcdsgen-arrow/src/tables/web_returns.rs
@@ -14,6 +14,11 @@ pub struct WebReturnsArrow {
 }
 
 impl WebReturnsArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::WebSales);
         Self {
@@ -47,7 +52,7 @@ impl WebReturnsArrow {
 
 impl RecordBatchReader for WebReturnsArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/web_sales.rs
+++ b/tpcdsgen-arrow/src/tables/web_sales.rs
@@ -14,6 +14,11 @@ pub struct WebSalesArrow {
 }
 
 impl WebSalesArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::WebSales);
         Self {
@@ -47,7 +52,7 @@ impl WebSalesArrow {
 
 impl RecordBatchReader for WebSalesArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpcdsgen-arrow/src/tables/web_site.rs
+++ b/tpcdsgen-arrow/src/tables/web_site.rs
@@ -17,6 +17,11 @@ pub struct WebSiteArrow {
 }
 
 impl WebSiteArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SCHEMA)
+    }
+
     pub fn new(session: Session) -> Self {
         let row_count = session.get_scaling().get_row_count(Table::WebSite);
         Self {
@@ -50,7 +55,7 @@ impl WebSiteArrow {
 
 impl RecordBatchReader for WebSiteArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/customer.rs
+++ b/tpchgen-arrow/src/customer.rs
@@ -50,6 +50,11 @@ pub struct CustomerArrow {
 }
 
 impl CustomerArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&CUSTOMER_SCHEMA)
+    }
+
     pub fn new(generator: CustomerGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -66,7 +71,7 @@ impl CustomerArrow {
 
 impl RecordBatchReader for CustomerArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&CUSTOMER_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/lineitem.rs
+++ b/tpchgen-arrow/src/lineitem.rs
@@ -57,6 +57,11 @@ pub struct LineItemArrow {
 }
 
 impl LineItemArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&LINEITEM_SCHEMA)
+    }
+
     pub fn new(generator: LineItemGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -73,7 +78,7 @@ impl LineItemArrow {
 
 impl RecordBatchReader for LineItemArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&LINEITEM_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/nation.rs
+++ b/tpchgen-arrow/src/nation.rs
@@ -49,6 +49,11 @@ pub struct NationArrow {
 }
 
 impl NationArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&NATION_SCHEMA)
+    }
+
     pub fn new(generator: NationGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -65,7 +70,7 @@ impl NationArrow {
 
 impl RecordBatchReader for NationArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&NATION_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/order.rs
+++ b/tpchgen-arrow/src/order.rs
@@ -52,6 +52,11 @@ pub struct OrderArrow {
 }
 
 impl OrderArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&ORDER_SCHEMA)
+    }
+
     pub fn new(generator: OrderGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -68,7 +73,7 @@ impl OrderArrow {
 
 impl RecordBatchReader for OrderArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&ORDER_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/part.rs
+++ b/tpchgen-arrow/src/part.rs
@@ -50,6 +50,11 @@ pub struct PartArrow {
 }
 
 impl PartArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&PART_SCHEMA)
+    }
+
     pub fn new(generator: PartGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -66,7 +71,7 @@ impl PartArrow {
 
 impl RecordBatchReader for PartArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&PART_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/partsupp.rs
+++ b/tpchgen-arrow/src/partsupp.rs
@@ -50,6 +50,11 @@ pub struct PartSuppArrow {
 }
 
 impl PartSuppArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&PARTSUPP_SCHEMA)
+    }
+
     pub fn new(generator: PartSuppGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -66,7 +71,7 @@ impl PartSuppArrow {
 
 impl RecordBatchReader for PartSuppArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&PARTSUPP_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/region.rs
+++ b/tpchgen-arrow/src/region.rs
@@ -44,6 +44,11 @@ pub struct RegionArrow {
 }
 
 impl RegionArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&REGION_SCHEMA)
+    }
+
     pub fn new(generator: RegionGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -60,7 +65,7 @@ impl RegionArrow {
 
 impl RecordBatchReader for RegionArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&REGION_SCHEMA)
+        Self::schema_ref()
     }
 }
 

--- a/tpchgen-arrow/src/supplier.rs
+++ b/tpchgen-arrow/src/supplier.rs
@@ -37,6 +37,11 @@ pub struct SupplierArrow {
 }
 
 impl SupplierArrow {
+    /// Return the schema without initializing a data generator.
+    pub fn schema_ref() -> SchemaRef {
+        Arc::clone(&SUPPLIER_SCHEMA)
+    }
+
     pub fn new(generator: SupplierGenerator<'static>) -> Self {
         Self {
             inner: generator.iter(),
@@ -53,7 +58,7 @@ impl SupplierArrow {
 
 impl RecordBatchReader for SupplierArrow {
     fn schema(&self) -> SchemaRef {
-        Arc::clone(&SUPPLIER_SCHEMA)
+        Self::schema_ref()
     }
 }
 


### PR DESCRIPTION
This adds `schema_ref()` to get a table's schema without creating a generator and an Arrow reader. It's the same change in all **33** files: **8** TPC-H readers and **25** TPC-DS readers. The existing `schema()` method now calls `schema_ref()`.

For `--column-encoding` in #405, we need to check whether a column name exists in a table. Right now, getting the schema requires creating a generator and an Arrow reader first. With direct schema access, we can reject invalid column names before initializing generators and keep argument validation separate from data generation.