### PR TITLE
ci: remove lint dependencies and add Rust caching

### DIFF
--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -90,6 +90,7 @@ jobs:
           args: --locked --release --out dist
           working-directory: tpchgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
+          sccache: true
       - name: Build tpcgen-cli wheel
         if: ${{ inputs.package == 'all' || inputs.package == 'tpcgen-cli' }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -98,6 +99,7 @@ jobs:
           args: --locked --release --out dist
           working-directory: tpcgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
+          sccache: true
       - name: Upload tpchgen-cli wheels
         if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpchgen-cli') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -21,8 +21,6 @@ jobs:
   wheels:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
-    env:
-      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
     strategy:
       matrix:
         include:
@@ -84,10 +82,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      # GitHub cache read-only mode requires a newer sccache than Maturin's minimum.
-      - name: Install sccache with read-only cache support
-        if: runner.os != 'Linux'
-        run: python3 -m pip install 'sccache>=0.16.0'
       - name: Build tpchgen-cli wheel
         if: ${{ inputs.package == 'all' || inputs.package == 'tpchgen-cli' }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -96,8 +90,6 @@ jobs:
           args: --locked --release --out dist
           working-directory: tpchgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
-          sccache: true
-          before-script-linux: uv tool install 'sccache>=0.16.0'
       - name: Build tpcgen-cli wheel
         if: ${{ inputs.package == 'all' || inputs.package == 'tpcgen-cli' }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -106,8 +98,6 @@ jobs:
           args: --locked --release --out dist
           working-directory: tpcgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
-          sccache: true
-          before-script-linux: uv tool install 'sccache>=0.16.0'
       - name: Upload tpchgen-cli wheels
         if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpchgen-cli') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-py-packages.yml
+++ b/.github/workflows/build-py-packages.yml
@@ -21,6 +21,8 @@ jobs:
   wheels:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    env:
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
     strategy:
       matrix:
         include:
@@ -82,6 +84,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # GitHub cache read-only mode requires a newer sccache than Maturin's minimum.
+      - name: Install sccache with read-only cache support
+        if: runner.os != 'Linux'
+        run: python3 -m pip install 'sccache>=0.16.0'
       - name: Build tpchgen-cli wheel
         if: ${{ inputs.package == 'all' || inputs.package == 'tpchgen-cli' }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -91,6 +97,7 @@ jobs:
           working-directory: tpchgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
           sccache: true
+          before-script-linux: uv tool install 'sccache>=0.16.0'
       - name: Build tpcgen-cli wheel
         if: ${{ inputs.package == 'all' || inputs.package == 'tpcgen-cli' }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -100,6 +107,7 @@ jobs:
           working-directory: tpcgen-cli
           manylinux: ${{ matrix.manylinux || '' }}
           sccache: true
+          before-script-linux: uv tool install 'sccache>=0.16.0'
       - name: Upload tpchgen-cli wheels
         if: ${{ inputs.upload-artifacts && (inputs.package == 'all' || inputs.package == 'tpchgen-cli') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/full-conformance.yml
+++ b/.github/workflows/full-conformance.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          shared-key: release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
@@ -78,7 +77,6 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          shared-key: release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
@@ -117,7 +115,6 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          shared-key: release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators

--- a/.github/workflows/full-conformance.yml
+++ b/.github/workflows/full-conformance.yml
@@ -38,17 +38,10 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
         run: cargo build --locked --release -p tpcgen-cli
@@ -83,17 +76,10 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
         run: cargo build --locked --release -p tpcgen-cli
@@ -129,17 +115,10 @@ jobs:
           java-version: '17'
 
       - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
         run: cargo build --locked --release -p tpcgen-cli

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Run cargo-fmt
         run: cargo fmt --all -- --check
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run cargo-clippy
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
       - name: Check
@@ -38,9 +41,11 @@ jobs:
   test-doc-examples:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Doc Examples (cargo test --workspace --doc)
         run: cargo test --locked --workspace --doc
 
@@ -48,9 +53,11 @@ jobs:
   test-workspace:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
         with:
           tool: nextest@0.9.140
@@ -63,9 +70,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name : Build docs
         env:
           RUSTDOCFLAGS: "-D warnings"
@@ -73,7 +82,6 @@ jobs:
 
   # Build wheels + sdist (but don’t upload artifacts)
   build-packages:
-    needs: lint
     uses: ./.github/workflows/build-py-packages.yml
     with:
       upload-artifacts: false

--- a/.github/workflows/tpcds-benchmark.yml
+++ b/.github/workflows/tpcds-benchmark.yml
@@ -29,17 +29,10 @@ jobs:
       uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
     - name: Cache Rust dependencies
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+        shared-key: release
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build release binaries
       run: |

--- a/.github/workflows/tpcds-benchmark.yml
+++ b/.github/workflows/tpcds-benchmark.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        shared-key: release
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build release binaries

--- a/.github/workflows/tpcds-conformance.yml
+++ b/.github/workflows/tpcds-conformance.yml
@@ -39,7 +39,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        shared-key: release
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build Rust table generators
@@ -67,7 +66,6 @@ jobs:
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        shared-key: release
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build Rust table generators

--- a/.github/workflows/tpcds-conformance.yml
+++ b/.github/workflows/tpcds-conformance.yml
@@ -37,17 +37,10 @@ jobs:
       uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
     - name: Cache Rust dependencies
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+        shared-key: release
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build Rust table generators
       run: |
@@ -72,17 +65,10 @@ jobs:
       uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
     - name: Cache Rust dependencies
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
+        shared-key: release
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Build Rust table generators
       run: |

--- a/.github/workflows/tpch-conformance.yml
+++ b/.github/workflows/tpch-conformance.yml
@@ -43,7 +43,6 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          shared-key: release
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators

--- a/.github/workflows/tpch-conformance.yml
+++ b/.github/workflows/tpch-conformance.yml
@@ -41,17 +41,10 @@ jobs:
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          shared-key: release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build Rust table generators
         run: |


### PR DESCRIPTION
This PR makes two changes to reduce CI waiting and repeated compilation:

1. **Remove `needs: lint` so independent jobs run in parallel.** Doc tests, workspace tests, documentation builds, and packaging previously waited for lint to finish. They can now start alongside it. The required `Rust checks` status still requires every job to pass.
2. **Cache Rust dependencies to reuse previous build work.** Add `Swatinem/rust-cache` to the Rust check jobs and replace `actions/cache` in conformance and benchmarks. This reuses downloaded dependencies and their compiled artifacts, with Rust-aware cache keys and a consistent write policy: only `main` saves caches; other refs can restore them.

Test commands and packaging coverage are unchanged.